### PR TITLE
Make it easy to use final published registry

### DIFF
--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -8,11 +8,14 @@ include $(tools_path)/crd.Makefile
 include $(tools_path)/app.Makefile
 include $(tools_path)/ubbagent.Makefile
 
+REGISTRY_FOR_DEPLOYER ?= $(APP_REGISTRY)
+$(info ---- REGISTRY_FOR_DEPLOYER = $(REGISTRY_FOR_DEPLOYER))
+
 app/build:: .build/deployer .build/elasticsearch .build/controller
 
 .build/deployer: deployer/* manifest/* $(MARKETPLACE_BASE_BUILD)/deployer-kubectl $(APP_BUILD)/registry_prefix | app/setup
 	docker build \
-	    --build-arg REGISTRY="$(APP_REGISTRY)" \
+	    --build-arg REGISTRY="$(REGISTRY_FOR_DEPLOYER)" \
 	    --build-arg TAG="$(APP_TAG)" \
 	    --build-arg MARKETPLACE_REGISTRY="$(MARKETPLACE_REGISTRY)" \
 	    --tag "$(APP_DEPLOYER_IMAGE)" \

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -8,11 +8,14 @@ include $(tools_path)/crd.Makefile
 include $(tools_path)/app.Makefile
 include $(tools_path)/ubbagent.Makefile
 
+REGISTRY_FOR_DEPLOYER ?= $(APP_REGISTRY)
+$(info ---- REGISTRY_FOR_DEPLOYER = $(REGISTRY_FOR_DEPLOYER))
+
 app/build:: .build/deployer .build/wordpress .build/init .build/mysql .build/controller .build/ubbagent
 
 .build/deployer: deployer/* manifest/* $(MARKETPLACE_BASE_BUILD)/deployer-kubectl .build/controller $(APP_BUILD)/registry_prefix | app/setup
 	docker build \
-	    --build-arg REGISTRY="$(APP_REGISTRY)" \
+	    --build-arg REGISTRY="$(REGISTRY_FOR_DEPLOYER)" \
 	    --build-arg TAG="$(APP_TAG)" \
 	    --build-arg MARKETPLACE_REGISTRY="$(MARKETPLACE_REGISTRY)" \
 	    --tag "$(APP_DEPLOYER_IMAGE)" \


### PR DESCRIPTION
As an example, we can build and push track `5` of `elasticsearch` to target staging repo using the following command:
```
cd k8s/elasticsearch

APP_TAG=5 \
REGISTRY=gcr.io/cloud-marketplace-ops-test \
REGISTRY_FOR_DEPLOYER=gcr.io/cloud-marketplace-staging/google/elasticsearch \
make app/build
```