### PR TITLE
Fix app variable name.

### DIFF
--- a/k8s/cassandra/Makefile
+++ b/k8s/cassandra/Makefile
@@ -10,14 +10,14 @@ TAG ?= latest
 $(info ---- TAG = $(TAG))
 
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/cassandra/deployer:$(TAG)
-NAME ?= cassandra-1
+APP_INSTANCE_NAME ?= cassandra-1
 
 ifdef REPLICAS
   REPLICAS_FIELD = , "REPLICAS": "$(REPLICAS)"
 endif
 
 APP_PARAMETERS ?= { \
-  "APP_INSTANCE_NAME": "$(NAME)", \
+  "APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", \
   "NAMESPACE": "$(NAMESPACE)"\
   $(REPLICAS_FIELD) \
 }

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -10,9 +10,9 @@ TAG ?= latest
 $(info ---- TAG = $(TAG))
 
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/elasticsearch/deployer:$(TAG)
-NAME ?= elasticsearch-1
+APP_INSTANCE_NAME ?= elasticsearch-1
 APP_PARAMETERS ?= { \
-  "APP_INSTANCE_NAME": "$(NAME)", \
+  "APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", \
   "NAMESPACE": "$(NAMESPACE)", \
   "REPLICAS": "2" \
 }

--- a/k8s/memcached/Makefile
+++ b/k8s/memcached/Makefile
@@ -10,9 +10,9 @@ TAG ?= latest
 $(info ---- TAG = $(TAG))
 
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/memcached/deployer:$(TAG)
-NAME ?= memcached-1
+APP_INSTANCE_NAME ?= memcached-1
 APP_PARAMETERS ?= { \
-  "APP_INSTANCE_NAME": "$(NAME)", \
+  "APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 APP_TEST_PARAMETERS ?= {}

--- a/k8s/rabbitmq/Makefile
+++ b/k8s/rabbitmq/Makefile
@@ -10,9 +10,9 @@ TAG ?= latest
 $(info ---- TAG = $(TAG))
 
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/rabbitmq/deployer:$(TAG)
-NAME ?= rabbitmq-1
+APP_INSTANCE_NAME ?= rabbitmq-1
 APP_PARAMETERS ?= { \
-  "APP_INSTANCE_NAME": "$(NAME)", \
+  "APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 APP_TEST_PARAMETERS ?= {}

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -10,9 +10,9 @@ TAG ?= latest
 $(info ---- TAG = $(TAG))
 
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/wordpress/deployer:$(TAG)
-NAME ?= wordpress-1
+APP_INSTANCE_NAME ?= wordpress-1
 APP_PARAMETERS ?= { \
-  "APP_INSTANCE_NAME": "$(NAME)", \
+  "APP_INSTANCE_NAME": "$(APP_INSTANCE_NAME)", \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 APP_TEST_PARAMETERS ?= {}


### PR DESCRIPTION
README has reference to $APP_INSTANCE_NAME instead of $NAME. It has been changed
in https://github.com/GoogleCloudPlatform/click-to-deploy/pull/33.