### PR TITLE
RabbitMQ - listen to the port 15672

### DIFF
--- a/k8s/rabbitmq/manifest/service-discovery.yaml.template
+++ b/k8s/rabbitmq/manifest/service-discovery.yaml.template
@@ -18,6 +18,8 @@ spec:
     port: 25672
   - name: epmd
     port: 4369
+  - name: http
+    port: 15672
   selector:
     app.kubernetes.io/name: $APP_INSTANCE_NAME
     app.kubernetes.io/component: rabbitmq-server

--- a/k8s/rabbitmq/manifest/service.yaml.template
+++ b/k8s/rabbitmq/manifest/service.yaml.template
@@ -17,6 +17,8 @@ spec:
     port: 25672
   - name: epmd
     port: 4369
+  - name: http
+    port: 15672
   selector:
     app.kubernetes.io/name: $APP_INSTANCE_NAME
     app.kubernetes.io/component: rabbitmq-server


### PR DESCRIPTION
This was incidentally deleted on https://github.com/GoogleCloudPlatform/click-to-deploy/pull/69, after merged with the master.