### PR TITLE
Use "agent" instead of "slave"

### DIFF
--- a/k8s/jenkins/manifest/manifests.yaml.template
+++ b/k8s/jenkins/manifest/manifests.yaml.template
@@ -88,7 +88,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: $APP_INSTANCE_NAME-jenkins-slaves-connector
+  name: $APP_INSTANCE_NAME-jenkins-agents-connector
   labels: &JenkinsDeploymentLabels
     app.kubernetes.io/name: $APP_INSTANCE_NAME
     app.kubernetes.io/component: jenkins-master
@@ -98,7 +98,7 @@ spec:
     - protocol: TCP
       port: 50000
       targetPort: 50000
-      name: slaves-connector
+      name: agents-connector
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
Commit originally came from https://github.com/GoogleCloudPlatform/click-to-deploy/pull/209 - creating a separate pull request to trigger cloudbuild integration.

* Google and contributors of this project do not affiliate with comments from #209.
* Updating Jenkins terminology to be more inclusive and consistent with Jenkins [intended naming convention](https://issues.jenkins-ci.org/browse/JENKINS-42816).

Fixes #209.