### PR TITLE
Replace gawk-specific feature of BEGINFILE with nawk compatible FNR==1

### DIFF
--- a/k8s/airflow-operator/README.md
+++ b/k8s/airflow-operator/README.md
@@ -156,7 +156,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_AIRFLOWOPERATOR
   $SERVICE_ACCOUNT' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"

--- a/k8s/cassandra/README.md
+++ b/k8s/cassandra/README.md
@@ -160,7 +160,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_CASSANDRA $REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/elastic-gke-logging/README.md
+++ b/k8s/elastic-gke-logging/README.md
@@ -179,7 +179,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE \
       $IMAGE_ELASTICSEARCH $IMAGE_KIBANA $IMAGE_FLUENTD $IMAGE_INIT $ELASTICSEARCH_REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"

--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -161,7 +161,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_ELASTICSEARCH $IMAGE_INIT $REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/grafana/README.md
+++ b/k8s/grafana/README.md
@@ -151,7 +151,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_GRAFANA $IMAGE_GRAFANA_INIT' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/influxdb/README.md
+++ b/k8s/influxdb/README.md
@@ -176,7 +176,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_INFLUXDB $INFLUXDB_ADMIN_USER $INFLUXDB_ADMIN_PASSWORD' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/jenkins/README.md
+++ b/k8s/jenkins/README.md
@@ -137,7 +137,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_JENKINS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/memcached/README.md
+++ b/k8s/memcached/README.md
@@ -152,7 +152,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_MEMCACHED $REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```
@@ -309,7 +309,7 @@ Console, or using `kubectl`.
     expanded manifest file for future updates to the application.
 
     ```shell
-    awk 'BEGINFILE {print "---"}{print}' manifest/* \
+    awk 'FNR==1 {print "---"}{print}' manifest/* \
       | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_MEMCACHED $REPLICAS' \
       > "${APP_INSTANCE_NAME}_manifest.yaml"
     ```

--- a/k8s/nginx/README.md
+++ b/k8s/nginx/README.md
@@ -168,7 +168,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_NGINX $IMAGE_NGINX_INIT $REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/postgresql/README.md
+++ b/k8s/postgresql/README.md
@@ -144,7 +144,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $IMAGE_POSTGRESQL $NAMESPACE $POSTGRESQL_DB_PASSWORD $POSTGRESQL_VOLUME_SIZE' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/prometheus/README.md
+++ b/k8s/prometheus/README.md
@@ -199,7 +199,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_PROMETHEUS $IMAGE_ALERTMANAGER $IMAGE_KUBE_STATE_METRICS $IMAGE_NODE_EXPORTER $IMAGE_PUSHGATEWAY $IMAGE_GRAFANA $IMAGE_PROMETHEUS_INIT $NAMESPACE $PROMETHEUS_REPLICAS' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/rabbitmq/README.md
+++ b/k8s/rabbitmq/README.md
@@ -216,7 +216,7 @@ expanded manifest file for future updates to the application.
 1. Expand `Application`/`Secret`/`StatefulSet`/`ConfigMap` YAML files.
 
     ```shell
-    awk 'BEGINFILE {print "---"}{print}' manifest/* \
+    awk 'FNR==1 {print "---"}{print}' manifest/* \
       | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_RABBITMQ $IMAGE_RABBITMQ_INIT $REPLICAS $RABBITMQ_ERLANG_COOKIE $RABBITMQ_DEFAULT_USER $RABBITMQ_DEFAULT_PASS $RABBITMQ_SERVICE_ACCOUNT' \
       > "${APP_INSTANCE_NAME}_manifest.yaml"
     ```

--- a/k8s/sample-app/README.md
+++ b/k8s/sample-app/README.md
@@ -120,7 +120,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_SAMPLE_APP $SAMPLE_APP_PARAMETER1' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```

--- a/k8s/spark-operator/README.md
+++ b/k8s/spark-operator/README.md
@@ -151,7 +151,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$name $namespace $sparkOperatorImage $serviceAccount' \
   > "${name}_manifest.yaml"
 ```

--- a/k8s/wordpress/README.md
+++ b/k8s/wordpress/README.md
@@ -160,7 +160,7 @@ Use `envsubst` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-awk 'BEGINFILE {print "---"}{print}' manifest/* \
+awk 'FNR==1 {print "---"}{print}' manifest/* \
   | envsubst '$APP_INSTANCE_NAME $NAMESPACE $IMAGE_WORDPRESS $IMAGE_MYSQL $ROOT_DB_PASSWORD $WORDPRESS_DB_PASSWORD' \
   > "${APP_INSTANCE_NAME}_manifest.yaml"
 ```


### PR DESCRIPTION
This PR is a follow up to #254 and #277. `BEGINFILE` is supported only in [`gawk`](https://www.gnu.org/software/gawk/manual/html_node/BEGINFILE_002fENDFILE.html) and `FNR==1` is compatible across different implementations, including `gawk` and `nawk`. Read more [here](https://www.gnu.org/software/gawk/manual/html_node/Other-Versions.html#Other-Versions).