### PR TITLE
Use ClusterRoleBinding for Prometheus Service Account to fix #316

### DIFF
--- a/k8s/prometheus/schema.yaml
+++ b/k8s/prometheus/schema.yaml
@@ -58,7 +58,7 @@ properties:
       type: SERVICE_ACCOUNT
       serviceAccount:
         roles:
-        - type: Role
+        - type: ClusterRole
           rulesType: PREDEFINED
           rulesFromRoleName: cluster-admin
   KUBE_STATE_METRICS_SERVICE_ACCOUNT:


### PR DESCRIPTION
The prometheus click-to-deploy will not operate on a GKE cluster as Prometheus fails when it can't list Pods at the cluster-wide. This change fixes that by using a `ClusterRoleBinding` rather than a `RoleBinding` of the `cluster-admin` `ClusterRole`. Fixed #316.