### PR TITLE
helm template Error: unknown flag: --name

### DIFF
--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -54,6 +54,7 @@ You'll need the following tools in your development environment:
 - [kubectl](https://kubernetes.io/docs/reference/kubectl/overview/)
 - [docker](https://docs.docker.com/install/)
 - [git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- [helm](https://github.com/helm/helm/blob/master/docs/install.md)
 
 Configure `gcloud` as a Docker credential helper:
 
@@ -166,7 +167,7 @@ kubectl create namespace "$NAMESPACE"
 Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
-Check if the `helm template` plugin is installed.
+Check to make sure the `helm template` plugin is installed.
 ```shell
 helm template --help
 ```

--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -217,7 +217,7 @@ To view the app, open the URL in your browser.
 By default, the application does not have an external IP. To create an external
 IP address, run the following command:
 
-```
+```shell
 kubectl patch svc "$APP_INSTANCE_NAME-elasticsearch-svc" \
   --namespace "$NAMESPACE" \
   --patch '{"spec": {"type": "LoadBalancer"}}'
@@ -231,7 +231,7 @@ If you run your Elasticsearch cluster behind a LoadBalancer service, use the
 following command to get the IP address. You can use the IP address to run
 administrative operations using the REST API:
 
-```
+```shell
 SERVICE_IP=$(kubectl get svc $APP_INSTANCE_NAME-elasticsearch-svc \
   --namespace $NAMESPACE \
   --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -272,7 +272,7 @@ In the response, you should see a message including Elasticsearch's tagline:
 
 Scale the number of master node replicas by the following command:
 
-```
+```shell
 kubectl scale statefulsets "$APP_INSTANCE_NAME-elasticsearch" \
   --namespace "$NAMESPACE" --replicas=<new-replicas>
 ```
@@ -398,7 +398,7 @@ back up your installation, to eliminate the risk of losing your data.
 
 Start with assigning the new image to your StatefulSet definition:
 
-```
+```shell
 IMAGE_ELASTICSEARCH=[NEW_IMAGE_REFERENCE]
 
 kubectl set image statefulset "${APP_INSTANCE_NAME}-elasticsearch" \

--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -166,9 +166,22 @@ kubectl create namespace "$NAMESPACE"
 Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
+Check if the `helm template` plugin is installed.
+```shell
+helm template --help
+```
+
+If not install it. 
+
+```shell
+helm plugin install https://github.com/technosophos/helm-template
+```
+
+Expand the template.
+
 ```shell
 helm template chart/elasticsearch \
-  --name $APP_INSTANCE_NAME \
+  --release $APP_INSTANCE_NAME \
   --namespace $NAMESPACE \
   --set elasticsearch.initImage=$IMAGE_INIT \
   --set elasticsearch.image=$IMAGE_ELASTICSEARCH \


### PR DESCRIPTION
1) I installed a new Elasticsearch instance using [these instructions](https://github.com/GoogleCloudPlatform/click-to-deploy/tree/master/k8s/elasticsearch) to my new [Kubernetes cluster on google cloud](https://console.cloud.google.com/kubernetes/clusters/details/us-west1-a/elasticsearch-cluster?project=plexiform-being-230702)

2) I attempted to expand the manifest template.
```shell
helm template chart/elasticsearch \
  --name $APP_INSTANCE_NAME \
  --namespace $NAMESPACE \
  --set elasticsearch.initImage=$IMAGE_INIT \
  --set elasticsearch.image=$IMAGE_ELASTICSEARCH \
  --set elasticsearch.replicas=$REPLICAS > "${APP_INSTANCE_NAME}_manifest.yaml"
```
> I got the following error:
```shell
-bash: helm: command not found
```
3) I installed `helm` to my google cloud Kubernetes cluster using [these instructions](https://cloud.google.com/solutions/continuous-integration-helm-concourse#install_helm)

4) I then moved the `helm` executable to the proper path.
```shell 
mv linux-amd64/helm /usr/local/bin/helm
```

5) I again tried to expand the manifest template per the [README](https://github.com/GoogleCloudPlatform/click-to-deploy/tree/master/k8s/elasticsearch)
```shell
helm template chart/elasticsearch \
  --name $APP_INSTANCE_NAME \
  --namespace $NAMESPACE \
  --set elasticsearch.initImage=$IMAGE_INIT \
  --set elasticsearch.image=$IMAGE_ELASTICSEARCH \
  --set elasticsearch.replicas=$REPLICAS > "${APP_INSTANCE_NAME}_manifest.yaml"
```
> I got the following error:
```shell
Error: unknown command "template" for "helm"
Run 'helm --help' for usage.
```
6) I installed the `helm template` plugin
```shell
helm plugin install https://github.com/technosophos/helm-template
```
7) Again I attempted to expand the manifest template per the [README](https://github.com/GoogleCloudPlatform/click-to-deploy/tree/master/k8s/elasticsearch)
```shell
helm template chart/elasticsearch \
  --name $APP_INSTANCE_NAME \
  --namespace $NAMESPACE \
  --set elasticsearch.initImage=$IMAGE_INIT \
  --set elasticsearch.image=$IMAGE_ELASTICSEARCH \
  --set elasticsearch.replicas=$REPLICAS > "${APP_INSTANCE_NAME}_manifest.yaml"
```

```shell
Error: unknown flag: --name
Usage:
  template [flags] CHART
Flags:
  -x, --execute stringArray   only execute the given templates.
  -n, --namespace string      namespace (default "NAMESPACE")
      --notes                 show the computed NOTES.txt file as well.
  -r, --release string        release name (default "RELEASE-NAME")
      --set stringArray       set values on the command line. See 'helm install -h'
  -f, --values valueFiles     specify one or more YAML files of values (default [])
  -v, --verbose               show the computed YAML values as well.
Error: plugin "template" exited with error
```
6) Referring to the [`helm template` docs](https://helm.sh/docs/helm/#helm-template) I discovered that `helm template` uses --release as the flag for name.

7) I was able to expand the manifest with the following script:
```shell
helm template chart/elasticsearch \
  --release $APP_INSTANCE_NAME \
  --namespace $NAMESPACE \
  --set elasticsearch.initImage=$IMAGE_INIT \
  --set elasticsearch.image=$IMAGE_ELASTICSEARCH \
  --set elasticsearch.replicas=$REPLICAS > "${APP_INSTANCE_NAME}_manifest.yaml"
```
In the Google Cloud shell it shows that I am running the following `helm version`:
```shell
Client: &version.Version{SemVer:"v2.6.2", GitCommit:"be3ae4ea91b2960be98c07e8f73754e67e87963c", GitTreeState:"clean"}
Server: &version.Version{SemVer:"v2.6.2", GitCommit:"be3ae4ea91b2960be98c07e8f73754e67e87963c", GitTreeState:"clean"}
```

