### PR TITLE
Adding default imageTester in test schema/yaml to make the cloudbuild tests reproducible in verification pipeline

### DIFF
--- a/k8s/agones/Makefile
+++ b/k8s/agones/Makefile
@@ -24,9 +24,6 @@ APP_PARAMETERS ?= { \
 }
 
 
-APP_TEST_PARAMETERS ?= { }
-
-
 app/build:: .build/agones/deployer \
             .build/agones/agones-controller \
             .build/agones/agones-sdk \

--- a/k8s/agones/Makefile
+++ b/k8s/agones/Makefile
@@ -24,8 +24,7 @@ APP_PARAMETERS ?= { \
 }
 
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/agones/deployer \

--- a/k8s/airflow-operator/Makefile
+++ b/k8s/airflow-operator/Makefile
@@ -15,8 +15,6 @@ APP_PARAMETERS ?= { \
 }
 TESTER_IMAGE ?= $(REGISTRY)/airflow-operator/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/airflow-operator/deployer \
             .build/airflow-operator/airflow-operator \

--- a/k8s/airflow-operator/Makefile
+++ b/k8s/airflow-operator/Makefile
@@ -15,8 +15,7 @@ APP_PARAMETERS ?= { \
 }
 TESTER_IMAGE ?= $(REGISTRY)/airflow-operator/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/airflow-operator/deployer \

--- a/k8s/airflow-operator/Makefile
+++ b/k8s/airflow-operator/Makefile
@@ -14,8 +14,8 @@ APP_PARAMETERS ?= { \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/airflow-operator/tester:$(TAG)
+
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/airflow-operator/apptest/deployer/schema.yaml
+++ b/k8s/airflow-operator/apptest/deployer/schema.yaml
@@ -1,3 +1,4 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG

--- a/k8s/airflow-operator/deployer/Dockerfile
+++ b/k8s/airflow-operator/deployer/Dockerfile
@@ -15,5 +15,5 @@ RUN cat /data/schema.yaml \
 
 RUN cat /data-test/schema.yaml \
     | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
-    > /date-test/schema.yaml.new \
-    && mv /date-test/schema.yaml.new /date-test/schema.yaml
+    > /data-test/schema.yaml.new \
+    && mv /data-test/schema.yaml.new /data-test/schema.yaml

--- a/k8s/airflow-operator/deployer/Dockerfile
+++ b/k8s/airflow-operator/deployer/Dockerfile
@@ -12,3 +12,8 @@ RUN cat /data/schema.yaml \
     | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
     > /data/schema.yaml.new \
     && mv /data/schema.yaml.new /data/schema.yaml
+
+RUN cat /data-test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /date-test/schema.yaml.new \
+    && mv /date-test/schema.yaml.new /date-test/schema.yaml

--- a/k8s/app.Makefile
+++ b/k8s/app.Makefile
@@ -23,13 +23,6 @@ $(shell echo '$(APP_PARAMETERS)' \
 endef
 
 
-# Combines APP_PARAMETERS and APP_TEST_PARAMETERS.
-define combined_parameters
-$(shell echo '$(APP_PARAMETERS)' '$(APP_TEST_PARAMETERS)' \
-    | docker run -i --entrypoint=/usr/bin/jq --rm $(APP_DEPLOYER_IMAGE) -s '.[0] * .[1]')
-endef
-
-
 ##### Helper targets #####
 
 
@@ -78,14 +71,13 @@ app/install:: app/build \
 app/install-test:: app/build \
                    .build/var/APP_DEPLOYER_IMAGE \
                    .build/var/APP_PARAMETERS \
-                   .build/var/APP_TEST_PARAMETERS \
                    .build/var/MARKETPLACE_TOOLS_TAG \
 	           | .build/app/dev
 	$(call print_target)
 	.build/app/dev \
 	    /scripts/install \
 	        --deployer='$(APP_DEPLOYER_IMAGE)' \
-	        --parameters='$(call combined_parameters)' \
+	        --parameters='$(APP_PARAMETERS)' \
 	        --entrypoint="/bin/deploy_with_tests.sh"
 
 
@@ -103,14 +95,13 @@ app/uninstall: .build/var/APP_DEPLOYER_IMAGE \
 app/verify: app/build \
             .build/var/APP_DEPLOYER_IMAGE \
             .build/var/APP_PARAMETERS \
-            .build/var/APP_TEST_PARAMETERS \
             .build/var/MARKETPLACE_TOOLS_TAG \
             | .build/app/dev
 	$(call print_target)
 	.build/app/dev \
 	    /scripts/verify \
 	          --deployer='$(APP_DEPLOYER_IMAGE)' \
-	          --parameters='$(call combined_parameters)' \
+	          --parameters='$(APP_PARAMETERS)' \
 	          --wait_timeout="$(VERIFY_WAIT_TIMEOUT)"
 
 

--- a/k8s/cassandra/Makefile
+++ b/k8s/cassandra/Makefile
@@ -26,8 +26,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/cassandra/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/cassandra/cassandra \
             .build/cassandra/deployer \

--- a/k8s/cassandra/Makefile
+++ b/k8s/cassandra/Makefile
@@ -27,7 +27,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/cassandra/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/cassandra/Makefile
+++ b/k8s/cassandra/Makefile
@@ -26,8 +26,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/cassandra/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/cassandra/cassandra \

--- a/k8s/cassandra/apptest/deployer/schema.yaml
+++ b/k8s/cassandra/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/cassandra/deployer/Dockerfile
+++ b/k8s/cassandra/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/cassandra.tar.gz /data/chart/
 COPY --from=build /tmp/test/cassandra.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/elastic-gke-logging/Makefile
+++ b/k8s/elastic-gke-logging/Makefile
@@ -46,7 +46,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/elastic-gke-logging/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/elastic-gke-logging/Makefile
+++ b/k8s/elastic-gke-logging/Makefile
@@ -45,8 +45,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/elastic-gke-logging/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/elastic-gke-logging/elasticsearch \

--- a/k8s/elastic-gke-logging/Makefile
+++ b/k8s/elastic-gke-logging/Makefile
@@ -45,8 +45,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/elastic-gke-logging/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/elastic-gke-logging/elasticsearch \
             .build/elastic-gke-logging/kibana \

--- a/k8s/elastic-gke-logging/apptest/deployer/schema.yaml
+++ b/k8s/elastic-gke-logging/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/elastic-gke-logging/deployer/Dockerfile
+++ b/k8s/elastic-gke-logging/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/elastic-gke-logging.tar.gz /data/chart/
 COPY --from=build /tmp/test/elastic-gke-logging.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/elastic-gke-logging/deployer/Dockerfile
+++ b/k8s/elastic-gke-logging/deployer/Dockerfile
@@ -30,5 +30,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/elastic-gke-logging.tar.gz /data/chart/
 COPY --from=build /tmp/test/elastic-gke-logging.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -32,8 +32,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/elasticsearch/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/elasticsearch/elasticsearch \

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -33,7 +33,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/elasticsearch/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -32,8 +32,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/elasticsearch/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/elasticsearch/elasticsearch \
             .build/elasticsearch/deployer \

--- a/k8s/elasticsearch/apptest/deployer/schema.yaml
+++ b/k8s/elasticsearch/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/elasticsearch/deployer/Dockerfile
+++ b/k8s/elasticsearch/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/elasticsearch.tar.gz /data/chart/
 COPY --from=build /tmp/test/elasticsearch.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/elasticsearch/deployer/Dockerfile
+++ b/k8s/elasticsearch/deployer/Dockerfile
@@ -30,5 +30,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/elasticsearch.tar.gz /data/chart/
 COPY --from=build /tmp/test/elasticsearch.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/grafana/Makefile
+++ b/k8s/grafana/Makefile
@@ -29,7 +29,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/grafana/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/grafana/Makefile
+++ b/k8s/grafana/Makefile
@@ -26,10 +26,6 @@ APP_PARAMETERS ?= { \
   $(IMAGE_GRAFANA_INIT_FIELD) \
 }
 
-TESTER_IMAGE ?= $(REGISTRY)/grafana/tester:$(TAG)
-
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/grafana/debian9 \
             .build/grafana/deployer \

--- a/k8s/grafana/Makefile
+++ b/k8s/grafana/Makefile
@@ -28,8 +28,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/grafana/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/grafana/debian9 \

--- a/k8s/grafana/Makefile
+++ b/k8s/grafana/Makefile
@@ -26,6 +26,8 @@ APP_PARAMETERS ?= { \
   $(IMAGE_GRAFANA_INIT_FIELD) \
 }
 
+TESTER_IMAGE ?= $(REGISTRY)/grafana/tester:$(TAG)
+
 
 app/build:: .build/grafana/debian9 \
             .build/grafana/deployer \

--- a/k8s/grafana/apptest/deployer/schema.yaml
+++ b/k8s/grafana/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/grafana/deployer/Dockerfile
+++ b/k8s/grafana/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/grafana.tar.gz /data/chart/
 COPY --from=build /tmp/test/grafana.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --form=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/grafana/deployer/Dockerfile
+++ b/k8s/grafana/deployer/Dockerfile
@@ -30,5 +30,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/grafana.tar.gz /data/chart/
 COPY --from=build /tmp/test/grafana.tar.gz /data-test/chart/
-COPY --form=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/influxdb/Makefile
+++ b/k8s/influxdb/Makefile
@@ -16,11 +16,8 @@ APP_PARAMETERS ?= { \
 }
 
 TESTER_IMAGE ?= $(REGISTRY)/influxdb/tester:$(TAG)
-
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
-
 
 app/build:: .build/influxdb/deployer \
             .build/influxdb/influxdb \

--- a/k8s/influxdb/Makefile
+++ b/k8s/influxdb/Makefile
@@ -16,8 +16,7 @@ APP_PARAMETERS ?= { \
 }
 
 TESTER_IMAGE ?= $(REGISTRY)/influxdb/tester:$(TAG)
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 app/build:: .build/influxdb/deployer \
             .build/influxdb/influxdb \

--- a/k8s/influxdb/Makefile
+++ b/k8s/influxdb/Makefile
@@ -16,7 +16,6 @@ APP_PARAMETERS ?= { \
 }
 
 TESTER_IMAGE ?= $(REGISTRY)/influxdb/tester:$(TAG)
-APP_TEST_PARAMETERS ?= { }
 
 app/build:: .build/influxdb/deployer \
             .build/influxdb/influxdb \

--- a/k8s/influxdb/apptest/deployer/schema.yaml
+++ b/k8s/influxdb/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/influxdb/deployer/Dockerfile
+++ b/k8s/influxdb/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/influxdb.tar.gz /data/chart/
 COPY --from=build /tmp/test/influxdb.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/jenkins/Makefile
+++ b/k8s/jenkins/Makefile
@@ -22,8 +22,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/jenkins/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/jenkins/deployer \

--- a/k8s/jenkins/Makefile
+++ b/k8s/jenkins/Makefile
@@ -22,8 +22,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/jenkins/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/jenkins/deployer \
             .build/jenkins/jenkins \

--- a/k8s/jenkins/Makefile
+++ b/k8s/jenkins/Makefile
@@ -23,7 +23,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/jenkins/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/jenkins/apptest/deployer/schema.yaml
+++ b/k8s/jenkins/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/jenkins/deployer/Dockerfile
+++ b/k8s/jenkins/deployer/Dockerfile
@@ -13,6 +13,11 @@ RUN cat /data/schema.yaml \
     > /data/schema.yaml.new \
     && mv /data/schema.yaml.new /data/schema.yaml
 
+RUN cat /data-test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /data-test/schema.yaml.new \
+    && mv /data-test/schema.yaml.new /data-test/schema.yaml
+
 RUN mv -f /bin/deploy.sh /bin/deploy-original.sh \
     && cp /bin/clean_iam_resources.sh /bin/clean_iam_resources-original.sh \
     && echo '#!/bin/bash\nexit' > /bin/clean_iam_resources.sh

--- a/k8s/memcached/Makefile
+++ b/k8s/memcached/Makefile
@@ -16,8 +16,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/memcached/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/memcached/deployer \
             .build/memcached/memcached \

--- a/k8s/memcached/Makefile
+++ b/k8s/memcached/Makefile
@@ -16,8 +16,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/memcached/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/memcached/deployer \

--- a/k8s/memcached/Makefile
+++ b/k8s/memcached/Makefile
@@ -17,7 +17,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/memcached/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/memcached/apptest/deployer/schema.yaml
+++ b/k8s/memcached/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/memcached/deployer/Dockerfile
+++ b/k8s/memcached/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/memcached.tar.gz /data/chart/
 COPY --from=build /tmp/test/memcached.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --form=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/memcached/deployer/Dockerfile
+++ b/k8s/memcached/deployer/Dockerfile
@@ -30,5 +30,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/memcached.tar.gz /data/chart/
 COPY --from=build /tmp/test/memcached.tar.gz /data-test/chart/
-COPY --form=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/nginx/Makefile
+++ b/k8s/nginx/Makefile
@@ -27,8 +27,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/nginx/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/nginx/debian9  \
             .build/nginx/deployer \

--- a/k8s/nginx/Makefile
+++ b/k8s/nginx/Makefile
@@ -27,8 +27,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/nginx/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/nginx/debian9  \

--- a/k8s/nginx/Makefile
+++ b/k8s/nginx/Makefile
@@ -28,7 +28,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/nginx/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/nginx/apptest/deployer/schema.yaml
+++ b/k8s/nginx/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/nginx/deployer/Dockerfile
+++ b/k8s/nginx/deployer/Dockerfile
@@ -21,9 +21,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/nginx.tar.gz /data/chart/
 COPY --from=build /tmp/test/nginx.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/nginx/deployer/Dockerfile
+++ b/k8s/nginx/deployer/Dockerfile
@@ -30,5 +30,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/nginx.tar.gz /data/chart/
 COPY --from=build /tmp/test/nginx.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/postgresql/Makefile
+++ b/k8s/postgresql/Makefile
@@ -18,8 +18,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/postgresql/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/postgresql/deployer \

--- a/k8s/postgresql/Makefile
+++ b/k8s/postgresql/Makefile
@@ -18,8 +18,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/postgresql/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/postgresql/deployer \
             .build/postgresql/postgresql \

--- a/k8s/postgresql/Makefile
+++ b/k8s/postgresql/Makefile
@@ -19,7 +19,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/postgresql/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/postgresql/apptest/deployer/schema.yaml
+++ b/k8s/postgresql/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/postgresql/deployer/Dockerfile
+++ b/k8s/postgresql/deployer/Dockerfile
@@ -21,12 +21,16 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
-
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/postgresql.tar.gz /data/chart/
 COPY --from=build /tmp/test/postgresql.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/
 
 RUN mv -f /bin/deploy.sh /bin/deploy-original.sh \

--- a/k8s/postgresql/deployer/Dockerfile
+++ b/k8s/postgresql/deployer/Dockerfile
@@ -30,7 +30,7 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/postgresql.tar.gz /data/chart/
 COPY --from=build /tmp/test/postgresql.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/
 
 RUN mv -f /bin/deploy.sh /bin/deploy-original.sh \

--- a/k8s/prometheus/Makefile
+++ b/k8s/prometheus/Makefile
@@ -49,8 +49,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/prometheus/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/prometheus/alertmanager \

--- a/k8s/prometheus/Makefile
+++ b/k8s/prometheus/Makefile
@@ -50,7 +50,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/prometheus/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/prometheus/Makefile
+++ b/k8s/prometheus/Makefile
@@ -49,8 +49,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/prometheus/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/prometheus/alertmanager \
             .build/prometheus/debian9 \

--- a/k8s/prometheus/apptest/deployer/schema.yaml
+++ b/k8s/prometheus/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/prometheus/deployer/Dockerfile
+++ b/k8s/prometheus/deployer/Dockerfile
@@ -12,3 +12,8 @@ RUN cat /data/schema.yaml \
     | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
     > /data/schema.yaml.new \
     && mv /data/schema.yaml.new /data/schema.yaml
+
+RUN cat /data-test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /data-test/schema.yaml.new \
+    && mv /data-test/schema.yaml.new /data-test/schema.yaml

--- a/k8s/rabbitmq/Makefile
+++ b/k8s/rabbitmq/Makefile
@@ -54,8 +54,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/rabbitmq/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/rabbitmq/debian9  \

--- a/k8s/rabbitmq/Makefile
+++ b/k8s/rabbitmq/Makefile
@@ -54,8 +54,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/rabbitmq/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/rabbitmq/debian9  \
             .build/rabbitmq/deployer \

--- a/k8s/rabbitmq/Makefile
+++ b/k8s/rabbitmq/Makefile
@@ -55,7 +55,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/rabbitmq/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/rabbitmq/apptest/deployer/schema.yaml
+++ b/k8s/rabbitmq/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/rabbitmq/deployer/Dockerfile
+++ b/k8s/rabbitmq/deployer/Dockerfile
@@ -33,5 +33,5 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/rabbitmq.tar.gz /data/chart/
 COPY --from=build /tmp/test/rabbitmq.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/rabbitmq/deployer/Dockerfile
+++ b/k8s/rabbitmq/deployer/Dockerfile
@@ -24,9 +24,14 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/rabbitmq.tar.gz /data/chart/
 COPY --from=build /tmp/test/rabbitmq.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/

--- a/k8s/sample-app/Makefile
+++ b/k8s/sample-app/Makefile
@@ -27,8 +27,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/sample-app/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/sample-app/deployer \

--- a/k8s/sample-app/Makefile
+++ b/k8s/sample-app/Makefile
@@ -27,8 +27,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/sample-app/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/sample-app/deployer \
             .build/sample-app/sample-app \

--- a/k8s/sample-app/Makefile
+++ b/k8s/sample-app/Makefile
@@ -28,7 +28,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/sample-app/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/sample-app/apptest/deployer/schema.yaml
+++ b/k8s/sample-app/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/sample-app/deployer/Dockerfile
+++ b/k8s/sample-app/deployer/Dockerfile
@@ -12,3 +12,8 @@ RUN cat /data/schema.yaml \
     | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
     > /data/schema.yaml.new \
     && mv /data/schema.yaml.new /data/schema.yaml
+
+RUN cat /data-test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /data-test/schema.yaml.new \
+    && mv /data-test/schema.yaml.new /data-test/schema.yaml

--- a/k8s/spark-operator/Makefile
+++ b/k8s/spark-operator/Makefile
@@ -14,8 +14,7 @@ APP_PARAMETERS ?= { \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/spark-operator/tester:$(TAG)
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/spark-operator/deployer \

--- a/k8s/spark-operator/Makefile
+++ b/k8s/spark-operator/Makefile
@@ -14,7 +14,6 @@ APP_PARAMETERS ?= { \
   "NAMESPACE": "$(NAMESPACE)" \
 }
 TESTER_IMAGE ?= $(REGISTRY)/spark-operator/tester:$(TAG)
-APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/spark-operator/deployer \

--- a/k8s/spark-operator/Makefile
+++ b/k8s/spark-operator/Makefile
@@ -15,7 +15,6 @@ APP_PARAMETERS ?= { \
 }
 TESTER_IMAGE ?= $(REGISTRY)/spark-operator/tester:$(TAG)
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/spark-operator/apptest/deployer/schema.yaml
+++ b/k8s/spark-operator/apptest/deployer/schema.yaml
@@ -1,3 +1,4 @@
 properties:
   testerImage:
+    default: $REGISTRY/tester:$TAG
     type: string

--- a/k8s/spark-operator/deployer/Dockerfile
+++ b/k8s/spark-operator/deployer/Dockerfile
@@ -12,3 +12,9 @@ RUN cat /data/schema.yaml \
     | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
     > /data/schema.yaml.new \
     && mv /data/schema.yaml.new /data/schema.yaml
+
+RUN cat /data-test/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /data-test/schema.yaml.new \
+    && mv /data-test/schema.yaml.new /data-test/schema.yaml
+

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -48,8 +48,7 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/wordpress/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { \
-}
+APP_TEST_PARAMETERS ?= { }
 
 
 app/build:: .build/wordpress/deployer \

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -49,7 +49,6 @@ APP_PARAMETERS ?= { \
 TESTER_IMAGE ?= $(REGISTRY)/wordpress/tester:$(TAG)
 
 APP_TEST_PARAMETERS ?= { \
-  "testerImage": "$(TESTER_IMAGE)" \
 }
 
 

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -48,8 +48,6 @@ APP_PARAMETERS ?= { \
 
 TESTER_IMAGE ?= $(REGISTRY)/wordpress/tester:$(TAG)
 
-APP_TEST_PARAMETERS ?= { }
-
 
 app/build:: .build/wordpress/deployer \
             .build/wordpress/mysql \

--- a/k8s/wordpress/apptest/deployer/schema.yaml
+++ b/k8s/wordpress/apptest/deployer/schema.yaml
@@ -1,5 +1,6 @@
 properties:
   testerImage:
     type: string
+    default: $REGISTRY/tester:$TAG
     x-google-property:
       type: IMAGE

--- a/k8s/wordpress/deployer/Dockerfile
+++ b/k8s/wordpress/deployer/Dockerfile
@@ -30,7 +30,7 @@ RUN cat /tmp/apptest/schema.yaml \
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/wordpress.tar.gz /data/chart/
 COPY --from=build /tmp/test/wordpress.tar.gz /data-test/chart/
-COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/
 
 ENV WAIT_FOR_READY_TIMEOUT 1800

--- a/k8s/wordpress/deployer/Dockerfile
+++ b/k8s/wordpress/deployer/Dockerfile
@@ -21,11 +21,16 @@ RUN cat /tmp/schema.yaml \
     > /tmp/schema.yaml.new \
     && mv /tmp/schema.yaml.new /tmp/schema.yaml
 
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
 COPY --from=build /tmp/wordpress.tar.gz /data/chart/
 COPY --from=build /tmp/test/wordpress.tar.gz /data-test/chart/
-COPY apptest/deployer/schema.yaml /data-test/
+COPY --from=build /tmp/apptest/deployer/schema.yaml /data-test/
 COPY --from=build /tmp/schema.yaml /data/
 
 ENV WAIT_FOR_READY_TIMEOUT 1800


### PR DESCRIPTION
The only way to pass test parameters to verification pipeline is through the default values of /data-test/schema.yaml, which make them mandatory for the verification to succeed.

Therefore, the use of APP_TEST_PARAMETERS should be discouraged going forward. At the same time I will make sure that this is properly documented and communicated to partners once we validate this approach.