### PR TITLE
Bump cassandra version to 3.11.4

### DIFF
--- a/vm/chef/cookbooks/cassandra/attributes/default.rb
+++ b/vm/chef/cookbooks/cassandra/attributes/default.rb
@@ -14,7 +14,7 @@
 
 # Remember to check if repo component update
 # is needed when changing the version.
-default['cassandra']['version'] = '3.11.3'
+default['cassandra']['version'] = '3.11.4'
 
 default['cassandra']['repo']['uri'] = 'http://www.apache.org/dist/cassandra/debian'
 default['cassandra']['repo']['components'] = ['311x', 'main']


### PR DESCRIPTION
Cassandra has been updated to 3.11.4 [upstream](http://dl.bintray.com/apache/cassandra/dists/311x/main/binary-amd64/Packages). Updating this attribute so the image can be built again.