### PR TITLE
Bump kafka version to 2.1.1

### DIFF
--- a/vm/chef/cookbooks/kafka/attributes/default.rb
+++ b/vm/chef/cookbooks/kafka/attributes/default.rb
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['kafka']['version'] = '2.1.0'
+default['kafka']['version'] = '2.1.1'
 default['scala']['version'] = '2.11'
 default['kafka']['packages'] = ['zookeeperd']


### PR DESCRIPTION
Kafka has been updated [upstream](https://www-us.apache.org/dist/kafka/2.1.1/). Updating this attribute so the image will build successfully. 