### PR TITLE
Update opt-c2d-scripts-zabbix.erb

### DIFF
--- a/vm/chef/cookbooks/zabbix/templates/default/opt-c2d-scripts-zabbix.erb
+++ b/vm/chef/cookbooks/zabbix/templates/default/opt-c2d-scripts-zabbix.erb
@@ -30,7 +30,7 @@ fi
 if [[ ! -n "$passadmin" ]]; then
   passfile=/var/tmp/zabbix-admin-password
   echo 'Generating random admin password.'
-  echo 'Password is stored in $passfile file.'
+  echo "Password is stored in $passfile file."
   echo 'Please, change it as soon as possible.'
   touch $passfile
   chown root:root $passfile


### PR DESCRIPTION
**Category:**

- [x] Virtual machines
- [ ] Kubernetes apps

---

Expressions don't expand in single quotes, use double quotes for that.