### PR TITLE
Add "needs-triage" tag. Add "kind" prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/docker_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/docker_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Container images
 about: Report an issue related to the Docker image
-labels: kind/docker, unassigned
+labels: kind/docker, to be investigated
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/docker_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/docker_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Container images
 about: Report an issue related to the Docker image
-labels: kind/docker, to be investigated
+labels: kind/docker, needs-triage
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/docker_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/docker_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Container images
 about: Report an issue related to the Docker image
-labels: docker
+labels: kind/docker, unassigned
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/k8s_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/k8s_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Kubernetes apps
 about: Report an issue related to the Kubernetes application
-labels: kind/k8s, to be investigated
+labels: kind/k8s, needs-triage
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/k8s_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/k8s_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Kubernetes apps
 about: Report an issue related to the Kubernetes application
-labels: kind/k8s, unassigned
+labels: kind/k8s, to be investigated
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/k8s_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/k8s_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Kubernetes apps
 about: Report an issue related to the Kubernetes application
-labels: k8s
+labels: kind/k8s, unassigned
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/vm_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/vm_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Virtual machines
 about: Report an issue related to the VM application
-labels: vm
+labels: kind/vm, unassigned
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/vm_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/vm_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Virtual machines
 about: Report an issue related to the VM application
-labels: kind/vm, unassigned
+labels: kind/vm, to be investigated
 ---
 
 **Category:**

--- a/.github/ISSUE_TEMPLATE/vm_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/vm_issue_template.md
@@ -1,7 +1,7 @@
 ---
 name: Virtual machines
 about: Report an issue related to the VM application
-labels: kind/vm, to be investigated
+labels: kind/vm, needs-triage
 ---
 
 **Category:**


### PR DESCRIPTION
**Category:**

- [x] Virtual machines
- [x] Kubernetes apps
- [x] Container images

---

1.    The label `needs-triage` means **"This wasn't investigate by the repo's owners yet"**.
The idea is to assigne this label to all new issues, to notice that
repo's owners haven't investigate the issue yet.

      After the investigation, the label should be dropped.

1.   Additionally, the `kind/` prefix has been added. Thanks to this, it's much easier to apply labels.

      ![veED4WqghR2](https://user-images.githubusercontent.com/13849267/57639329-f57f5480-75af-11e9-9260-76def674515e.png)

