### PR TITLE
Updated influxdb-secrets.yaml, using stringData

### DIFF
--- a/k8s/influxdb/chart/influxdb/templates/influxdb-secrets.yaml
+++ b/k8s/influxdb/chart/influxdb/templates/influxdb-secrets.yaml
@@ -7,5 +7,4 @@ metadata:
     app.kubernetes.io/component: influxdb-server
 stringData:
   influxdb-admin: {{ .Values.admin.user }}
-data:
   influxdb-pass: {{ .Values.admin.password }}


### PR DESCRIPTION
Using stringData for password as there are original issues when passing in a base64 encoded password when using the command line installation

**Category:**

- [ ] Virtual machines
- [- ] Kubernetes apps
- [ ] Container images

---

<!-- 1. Please select the category from the list above. -->
<!-- 2. Please describe the PR below. -->

When using the original data field for the admin password the base64 encrypted value created in the command line installation process was causing a bad injection into the create user query in the install script in the influxdb docker image. This bad injection meant that the query was being corrupted and the admin user account was not being created.

This is fixed by using the password as a stringData field, the password base64 encryption is then independent of the client machine.
