### PR TITLE
Update Ubuntu gcr.io

### DIFF
--- a/k8s/elastic-gke-logging/Makefile
+++ b/k8s/elastic-gke-logging/Makefile
@@ -119,8 +119,8 @@ app/build:: .build/elastic-gke-logging/elasticsearch \
 .build/elastic-gke-logging/ubuntu16_04: .build/var/REGISTRY \
                                         .build/var/TAG \
                                         | .build/elastic-gke-logging
-	docker pull marketplace.gcr.io/google/ubuntu16_04
-	docker tag marketplace.gcr.io/google/ubuntu16_04 \
+	docker pull marketplace.gcr.io/google/ubuntu1604
+	docker tag marketplace.gcr.io/google/ubuntu1604 \
 	    "$(REGISTRY)/elastic-gke-logging/ubuntu16_04:$(TAG)"
 	docker push "$(REGISTRY)/elastic-gke-logging/ubuntu16_04:$(TAG)"
 	@touch "$@"

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -82,8 +82,8 @@ app/build:: .build/elasticsearch/elasticsearch \
 .build/elasticsearch/ubuntu16_04: .build/var/REGISTRY \
                                   .build/var/TAG \
                                   | .build/elasticsearch
-	docker pull marketplace.gcr.io/google/ubuntu16_04
-	docker tag marketplace.gcr.io/google/ubuntu16_04 \
+	docker pull marketplace.gcr.io/google/ubuntu1604
+	docker tag marketplace.gcr.io/google/ubuntu1604 \
 	    "$(REGISTRY)/elasticsearch/ubuntu16_04:$(TAG)"
 	docker push "$(REGISTRY)/elasticsearch/ubuntu16_04:$(TAG)"
 	@touch "$@"


### PR DESCRIPTION
It seems like `marketplace.gcr.io` for Ubuntu has been changed. The new address is http://marketplace.gcr.io/google/ubuntu1604:latest.