### PR TITLE
Enabled/disabled kalm supported.

### DIFF
--- a/k8s/cassandra/schema.yaml
+++ b/k8s/cassandra/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: true
+    kalmSupported: false
 
   images:
     '':

--- a/k8s/elasticsearch/schema.yaml
+++ b/k8s/elasticsearch/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: true
+    kalmSupported: false
 
   images:
     '':

--- a/k8s/jenkins/schema.yaml
+++ b/k8s/jenkins/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: false
+    kalmSupported: true
 
   images:
     '':

--- a/k8s/mariadb/schema.yaml
+++ b/k8s/mariadb/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: false
+    kalmSupported: true
 
   images:
     '':

--- a/k8s/postgresql/schema.yaml
+++ b/k8s/postgresql/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: false
+    kalmSupported: true
 
   images:
     '':

--- a/k8s/rabbitmq/schema.yaml
+++ b/k8s/rabbitmq/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: false
+    kalmSupported: true
 
   images:
     '':

--- a/k8s/sonarqube/schema.yaml
+++ b/k8s/sonarqube/schema.yaml
@@ -12,7 +12,7 @@ x-google-marketplace:
     recommended: false
 
   managedUpdates:
-    kalmSupported: false
+    kalmSupported: true
 
   images:
     '':


### PR DESCRIPTION
Cassandra, Elastic GKE Logging and Elasticsearch have
`updateStrategy=OnDelete`, so I'm going to disabled the support for now.

<!--- /gcbrun -->