### PR TITLE
Adding dependencies to persona-toolkit setup 

### DIFF
--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -67,7 +67,7 @@ readonly percona_toolkit_path='/opt/percona-toolkit'
 if [[ "${install_percona_toolkit}" == "True" ]]; then
  percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
  if [[ -n "${percona_toolkit_file}" ]]; then
-   dpkg -i "${percona_toolkit_path}/${percona_toolkit_file}"
+   dpkg -i "${percona_toolkit_path}/*"
    rm -rf "${percona_toolkit_path}"
  else
    apt_retry install -y percona-toolkit

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -58,21 +58,18 @@ service mysql stop
 
 # Grab the incoming options
 readonly cluster_name="$(get_attribute_value "ENV_CLUSTER_NAME")"
-readonly install_percona_toolkit="$(get_attribute_value "INSTALL_PERCONA_TOOLKIT")"
+readonly install_percona_toolkit="$(get_attribute_value "INSTALL_PERCONA_TOOLKIT") | tr '[:upper:]' '[:lower:]'"
 readonly mysql_root_password="$(get_attribute_value "MYSQL_ROOT_PASSWORD")"
 readonly percona_disk_name="$hostname-data"
-readonly percona_toolkit_path='/opt/percona-toolkit'
 
 # Add Percona Toolkit, if user requests it.
-if [[ "${install_percona_toolkit}" == "True" ]]; then
- percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
- if [[ -n "${percona_toolkit_file}" ]]; then
-   ls -l
-   apt_retry -o Dir::Cache::archives="$percona_toolkit_path" install percona-toolkit -yqq
-   rm -rf "${percona_toolkit_path}"
- else
-   apt_retry install -y percona-toolkit
- fi
+if [[ "${install_percona_toolkit:-}" == "true" ]]; then
+ echo "percona-toolkit has been selected to be installed."
+ export DEBIAN_FRONTEND='noninteractive'
+ apt_retry -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -yqq
+ elif [[ "${install_percona_toolkit:-}" == "false" ]]; then
+  echo "percona-toolkit not selected for install."
+  rm -rf /opt/c2d/downloads/percona-toolkit
 fi
 
 # Wait for the external disk to be created and then mount and format

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -28,8 +28,7 @@
 source /opt/c2d/c2d-utils || exit 1
 
 ##  Functions
-apt_retry () {
-  set +e
+function apt_retry () {
   local cmds="apt-get $@"
   local backoff=10
   echo "Running cmd: $cmds"
@@ -46,10 +45,7 @@ apt_retry () {
       exit 1
     fi
   done
-  set -e
 }
-
-apt_retry update -q
 
 set -o pipefail
 readonly hostname="$(hostname)"
@@ -63,11 +59,11 @@ readonly mysql_root_password="$(get_attribute_value "MYSQL_ROOT_PASSWORD")"
 readonly percona_disk_name="$hostname-data"
 
 # Add Percona Toolkit, if user requests it.
-if [[ "${install_percona_toolkit:-}" == "true" ]]; then
+if [[ "${install_percona_toolkit:-}" == "True" ]]; then
  echo "percona-toolkit has been selected to be installed."
  export DEBIAN_FRONTEND='noninteractive'
- apt_retry -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -yqq
- elif [[ "${install_percona_toolkit:-}" == "false" ]]; then
+ apt_retry -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
+ elif [[ "${install_percona_toolkit:-}" == "False" ]]; then
   echo "percona-toolkit not selected for install."
   rm -rf /opt/c2d/downloads/percona-toolkit
 fi

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -67,6 +67,7 @@ readonly percona_toolkit_path='/opt/percona-toolkit'
 if [[ "${install_percona_toolkit}" == "True" ]]; then
  percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
  if [[ -n "${percona_toolkit_file}" ]]; then
+   ls -l
    dpkg -i "${percona_toolkit_path}/"*.deb
    rm -rf "${percona_toolkit_path}"
  else

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -32,17 +32,17 @@ apt_retry () {
   set +e
   local cmds="apt-get $@"
   local backoff=10
-  echo "Running cmd: $cmds" >> /dev/stdout
+  echo "Running cmd: $cmds"
   while ! ${cmds} 2>&1; do
     if (( "${backoff}" < 100)); then
-      echo "Error: command failed: ${cmds}" >> /dev/stderr
-      echo "Backoff and retry in $backoff seconds." >> /dev/stderr
+      echo "Error: command failed: ${cmds}"
+      echo "Backoff and retry in $backoff seconds."
       sleep ${backoff}
       backoff=$(( backoff * 2 ))
     else
       # Fail installation.
       # Return > 0, so that Launcher communicates the failure to customers.
-      echo "Command failed. Terminating installation." >> /dev/stderr
+      echo "Command failed. Terminating installation."
       exit 1
     fi
   done

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -67,7 +67,7 @@ readonly percona_toolkit_path='/opt/percona-toolkit'
 if [[ "${install_percona_toolkit}" == "True" ]]; then
  percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
  if [[ -n "${percona_toolkit_file}" ]]; then
-   dpkg -i "${percona_toolkit_path}/*"
+   dpkg -i "${percona_toolkit_path}/"*.deb
    rm -rf "${percona_toolkit_path}"
  else
    apt_retry install -y percona-toolkit

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -68,7 +68,7 @@ if [[ "${install_percona_toolkit}" == "True" ]]; then
  percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
  if [[ -n "${percona_toolkit_file}" ]]; then
    ls -l
-   dpkg -i "${percona_toolkit_path}/"*.deb
+   apt_retry -o Dir::Cache::archives="$percona_toolkit_path" install percona-toolkit -yqq
    rm -rf "${percona_toolkit_path}"
  else
    apt_retry install -y percona-toolkit

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -33,7 +33,7 @@ bash 'Download percona-toolkit package' do
   code <<-EOH
     mkdir -p /opt/percona-toolkit
     cd /opt/percona-toolkit
-    apt-get download percona-toolkit
+    apt-get install -yqq --download-only -o Dir::Cache::archive="/opt/percona-toolkit/" percona-toolkit
     cd -
 EOH
 end

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -32,7 +32,7 @@ end
 bash 'Download percona-toolkit package and dependencies' do
   code <<-EOH
     mkdir -p /opt/c2d/downloads/percona-toolkit
-    cd /opt/percona-toolkit
+    cd /opt/c2d/downloads/percona-toolkit
     apt-get -d -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
     ls -la
     cd -

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -33,7 +33,7 @@ bash 'Download percona-toolkit package' do
   code <<-EOH
     mkdir -p /opt/percona-toolkit
     cd /opt/percona-toolkit
-    apt-get --download-only -o Dir::Cache::archives="/opt/percona-toolkit" install -yqq percona-toolkit
+    apt-get -d -o Dir::Cache::archives="/opt/percona-toolkit" install percona-toolkit -y
     cd -
 EOH
 end

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -30,12 +30,10 @@ execute 'apt-get update' do
 end
 
 bash 'Download percona-toolkit package and dependencies' do
+  cwd '/opt/c2d/downloads'
   code <<-EOH
     mkdir -p /opt/c2d/downloads/percona-toolkit
-    cd /opt/c2d/downloads/percona-toolkit
     apt-get -d -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
-    ls -la
-    cd -
 EOH
 end
 

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -31,9 +31,9 @@ end
 
 bash 'Download percona-toolkit package and dependencies' do
   code <<-EOH
-    mkdir -p /opt/percona-toolkit
+    mkdir -p /opt/c2d/downloads/percona-toolkit
     cd /opt/percona-toolkit
-    apt-get -d -o Dir::Cache::archives="/opt/percona-toolkit" install percona-toolkit -y
+    apt-get -d -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
     ls -la
     cd -
 EOH

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -29,11 +29,12 @@ execute 'apt-get update' do
   retry_delay 30
 end
 
-bash 'Download percona-toolkit package' do
+bash 'Download percona-toolkit package and dependencies' do
   code <<-EOH
     mkdir -p /opt/percona-toolkit
     cd /opt/percona-toolkit
     apt-get -d -o Dir::Cache::archives="/opt/percona-toolkit" install percona-toolkit -y
+    ls -la
     cd -
 EOH
 end

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -33,7 +33,7 @@ bash 'Download percona-toolkit package' do
   code <<-EOH
     mkdir -p /opt/percona-toolkit
     cd /opt/percona-toolkit
-    apt-get install -yqq --download-only -o Dir::Cache::archive="/opt/percona-toolkit/" percona-toolkit
+    apt-get --download-only -o Dir::Cache::archives="/opt/percona-toolkit" install -yqq percona-toolkit
     cd -
 EOH
 end


### PR DESCRIPTION
<!--- /gcbrun -->

**Category:**

- [x] Virtual machines
- [ ] Kubernetes apps
- [ ] Container images

---

<!-- 1. Please select the category from the list above. -->
<!-- 2. Please describe the PR below. -->
The addition of the percona-toolkit install broke the deployment due to missing dependencies. Adding dependency download and install to allow for offline install. Addresses #660  

