### PR TITLE
Add dependencies for percona-toolkit

### DIFF
--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -32,17 +32,17 @@ apt_retry () {
   set +e
   local cmds="apt-get $@"
   local backoff=10
-  echo "Running cmd: $cmds" >> /dev/stdout
+  echo "Running cmd: $cmds"
   while ! ${cmds} 2>&1; do
     if (( "${backoff}" < 100)); then
-      echo "Error: command failed: ${cmds}" >> /dev/stderr
-      echo "Backoff and retry in $backoff seconds." >> /dev/stderr
+      echo "Error: command failed: ${cmds}"
+      echo "Backoff and retry in $backoff seconds."
       sleep ${backoff}
       backoff=$(( backoff * 2 ))
     else
       # Fail installation.
       # Return > 0, so that Launcher communicates the failure to customers.
-      echo "Command failed. Terminating installation." >> /dev/stderr
+      echo "Command failed. Terminating installation."
       exit 1
     fi
   done
@@ -61,13 +61,13 @@ readonly cluster_name="$(get_attribute_value "ENV_CLUSTER_NAME")"
 readonly install_percona_toolkit="$(get_attribute_value "INSTALL_PERCONA_TOOLKIT")"
 readonly mysql_root_password="$(get_attribute_value "MYSQL_ROOT_PASSWORD")"
 readonly percona_disk_name="$hostname-data"
-readonly percona_toolkit_path='/opt/percona-toolkit'
+readonly percona_toolkit_path='/opt/c2d/downloads/percona-toolkit'
 
 # Add Percona Toolkit, if user requests it.
 if [[ "${install_percona_toolkit}" == "True" ]]; then
  percona_toolkit_file=$(ls $percona_toolkit_path | grep 'percona-toolkit')
  if [[ -n "${percona_toolkit_file}" ]]; then
-   dpkg -i "${percona_toolkit_path}/${percona_toolkit_file}"
+   apt_retry -o Dir::Cache::archives="${percona_toolkit_path}" install percona-toolkit -y
    rm -rf "${percona_toolkit_path}"
  else
    apt_retry install -y percona-toolkit

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -30,9 +30,9 @@ source /opt/c2d/c2d-utils || exit 1
 ##  Functions
 apt_retry () {
   set +e
-  local cmds="apt-get $@" >> /dev/stdout
+  local cmds="apt-get $@"
   local backoff=10
-  echo "Running cmd: $cmds"
+  echo "Running cmd: $cmds" >> /dev/stdout
   while ! ${cmds} 2>&1; do
     if (( "${backoff}" < 100)); then
       echo "Error: command failed: ${cmds}" >> /dev/stderr

--- a/vm/chef/cookbooks/percona/files/percona-setup
+++ b/vm/chef/cookbooks/percona/files/percona-setup
@@ -30,19 +30,19 @@ source /opt/c2d/c2d-utils || exit 1
 ##  Functions
 apt_retry () {
   set +e
-  local cmds="apt-get $@"
+  local cmds="apt-get $@" >> /dev/stdout
   local backoff=10
   echo "Running cmd: $cmds"
   while ! ${cmds} 2>&1; do
     if (( "${backoff}" < 100)); then
-      echo "Error: command failed: ${cmds}"
-      echo "Backoff and retry in $backoff seconds."
+      echo "Error: command failed: ${cmds}" >> /dev/stderr
+      echo "Backoff and retry in $backoff seconds." >> /dev/stderr
       sleep ${backoff}
       backoff=$(( backoff * 2 ))
     else
       # Fail installation.
       # Return > 0, so that Launcher communicates the failure to customers.
-      echo "Command failed. Terminating installation."
+      echo "Command failed. Terminating installation." >> /dev/stderr
       exit 1
     fi
   done

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -32,9 +32,7 @@ end
 bash 'Download percona-toolkit package and dependencies' do
   code <<-EOH
     mkdir -p /opt/c2d/downloads/percona-toolkit
-    cd /opt/c2d/downloads/percona-toolkit
     apt-get -d -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
-    cd -
 EOH
 end
 

--- a/vm/chef/cookbooks/percona/recipes/default.rb
+++ b/vm/chef/cookbooks/percona/recipes/default.rb
@@ -29,11 +29,11 @@ execute 'apt-get update' do
   retry_delay 30
 end
 
-bash 'Download percona-toolkit package' do
+bash 'Download percona-toolkit package and dependencies' do
   code <<-EOH
-    mkdir -p /opt/percona-toolkit
-    cd /opt/percona-toolkit
-    apt-get download percona-toolkit
+    mkdir -p /opt/c2d/downloads/percona-toolkit
+    cd /opt/c2d/downloads/percona-toolkit
+    apt-get -d -o Dir::Cache::archives="/opt/c2d/downloads/percona-toolkit" install percona-toolkit -y
     cd -
 EOH
 end


### PR DESCRIPTION
<!--- /gcbrun -->

**Category:**

- [x] Virtual machines
- [ ] Kubernetes apps
- [ ] Container images

---

<!-- 1. Please select the category from the list above. -->
<!-- 2. Please describe the PR below. -->
The addition of the percona-toolkit install broke the deployment due to missing dependencies. Adding dependency download and install to allow for offline install. Addresses #660