### PR TITLE
[Makefile] Add vm-generate-triggers target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,16 @@ matrix:
   include:
   - language: python
     python: 2.7
-    install: pip install jinja2
+    install: pip install jinja2 pyyaml
     env: TARGET=python-test
   - language: ruby
     install: gem install foodcritic
     env: TARGET=vm-lint
+  - language: generic
+    dist: xenial
+    before_install:
+    - wget https://packages.chef.io/files/stable/chefdk/4.2.0/ubuntu/16.04/chefdk_4.2.0-1_amd64.deb
+    - sudo dpkg -i chefdk_4.2.0-1_amd64.deb
+    env: TARGET=vm-generate-triggers
 
 script: make "${TARGET}"

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ python-test: ## Runs tests for Python scripts
 vm-lint: ## Runs lint for Chef cookbooks
 	@foodcritic --version
 	@foodcritic --cookbook-path=vm/chef/cookbooks --rule-file=vm/chef/.foodcritic --epic-fail=any
+
+.PHONY: vm-generate-triggers
+vm-generate-triggers: ## Generates and displays GCB triggers for VM
+	@python scripts/triggers_vm_generator.py

--- a/scripts/cloudbuild_k8s_generator.py
+++ b/scripts/cloudbuild_k8s_generator.py
@@ -178,7 +178,8 @@ steps:
 """.strip()
 
 
-class CloudBuildConfig():
+class CloudBuildConfig(object):
+  """Generates Cloud Build config for K8s app."""
 
   def __init__(self, solution):
     self._solution = solution
@@ -187,6 +188,7 @@ class CloudBuildConfig():
     self.path = None
     self.template = CLOUDBUILD_TEMPLATE
 
+  @property
   def exists(self):
     return os.path.isfile(self.path)
 
@@ -195,7 +197,7 @@ class CloudBuildConfig():
         solution=self._solution, extra_configs=self.extra_configs)
 
   def verify(self):
-    if not self.exists():
+    if not self.exists:
       return False
 
     with open(self.path, 'r') as cloudbuild_file:
@@ -212,15 +214,9 @@ class CloudBuildConfig():
 def main():
   parser = argparse.ArgumentParser()
   parser.add_argument(
-      '--solution',
-      type=str,
-      required=True,
-      help='solution name')
+      '--solution', type=str, required=True, help='solution name')
   parser.add_argument(
-      '--output',
-      type=str,
-      required=True,
-      help='path to save configuration')
+      '--output', type=str, required=True, help='path to save configuration')
   parser.add_argument(
       '--verify_only',
       action='store_true',
@@ -253,13 +249,13 @@ def main():
   if args.verify_only:
     if cloudbuild.verify():
       print('The %s file is up-to-date' % path)
-      os.sys.exit(0)
+      return 0
     else:
       print('The %s file is not up-to-date. Please re-generate it' % path)
-      os.sys.exit(1)
+      return 1
   else:
     cloudbuild.save()
 
 
 if __name__ == '__main__':
-  main()
+  os.sys.exit(main())

--- a/scripts/cloudbuild_k8s_generator_test.py
+++ b/scripts/cloudbuild_k8s_generator_test.py
@@ -185,7 +185,7 @@ class CloudBuildK8sGeneratorTest(unittest.TestCase):
     with tempfile.NamedTemporaryFile(delete=True) as f:
       cloudbuild = cloudbuild_k8s_generator.CloudBuildConfig(solution='unknown')
       cloudbuild.path = f.name
-      self.assertTrue(cloudbuild.exists())
+      self.assertTrue(cloudbuild.exists)
 
   def test_verify(self):
     cloudbuild_config = """
@@ -306,7 +306,7 @@ class CloudBuildK8sGeneratorTest(unittest.TestCase):
           solution='wordpress')
       cloudbuild.path = f.name
       cloudbuild.remove()
-      self.assertFalse(cloudbuild.exists())
+      self.assertFalse(cloudbuild.exists)
 
 
 if __name__ == '__main__':

--- a/scripts/triggers_vm_generator.py
+++ b/scripts/triggers_vm_generator.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+#
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import logging
+import multiprocessing.pool
+import os
+import subprocess
+import sys
+import yaml
+
+CLOUDBUILD_CONFIG_FILE = 'cloudbuild-vm.yaml'
+COOKBOOKS_DIR = 'vm/chef/cookbooks'
+PACKER_DIR = 'vm/packer/templates'
+TESTS_DIR = 'vm/tests/solutions/spec'
+
+_COOKBOOKS = {}
+
+
+class VmTriggerConfig(object):
+  """Generates GCB trigger for VM solution."""
+
+  def __init__(self, solution, knife_binary):
+    self._solution = solution
+    self._knife_binary = knife_binary
+
+  @property
+  def packer_run_list(self):
+    """Returns Chef's run_list from Packer's template."""
+    with open(os.path.join(self.packer_dir, 'packer.in.json')) as json_file:
+      data = json.load(json_file)
+      run_list = data['chef']['run_list']
+    return [cookbook.split('::', 1)[0] for cookbook in run_list]
+
+  @property
+  def should_include_test(self):
+    """Returns whether solution has tests."""
+    return True
+
+  @property
+  def packer_dir(self):
+    """Returns path to the Packer's template directory."""
+    return os.path.join(PACKER_DIR, self._solution)
+
+  @property
+  def tests_dir(self):
+    """Returns path to the tests directory."""
+    return os.path.join(TESTS_DIR, self._solution)
+
+  @property
+  def included_files(self):
+    """Returns list of included files."""
+    included_files = [
+        os.path.join(self.packer_dir, '**'), CLOUDBUILD_CONFIG_FILE
+    ]
+
+    if self.should_include_test:
+      included_files.append(os.path.join(self.tests_dir, '**'))
+
+    for cookbook in self.packer_run_list:
+      for dep in get_cookbook_deps(
+          cookbook=cookbook, knife_binary=self._knife_binary):
+        included_files.append(os.path.join('vm/chef', dep, '**'))
+
+    included_files = self._remove_duplicates(included_files)
+    return included_files
+
+  def _remove_duplicates(self, included_files):
+    """Removes duplicates from a List."""
+    final_list = []
+    for num in included_files:
+      if num not in final_list:
+        final_list.append(num)
+    return final_list
+
+  def generate_config(self):
+    """Generates GCB trigger config."""
+    included_files = self.included_files
+    included_files.sort()
+    trigger = {
+        'description': 'Trigger for VM %s' % self._solution,
+        'filename': CLOUDBUILD_CONFIG_FILE,
+        'github': {
+            'name': 'click-to-deploy',
+            'owner': 'GoogleCloudPlatform',
+            'pullRequest': {
+                'branch': '.*',
+                'commentControl': 'COMMENTS_ENABLED'
+            }
+        },
+        'includedFiles': included_files,
+        'substitutions': {
+            '_SOLUTION_NAME': self._solution
+        }
+    }
+    return trigger
+
+
+class CreateThreadPoolAndWait(object):
+  """Creates thread pool and wait for all jobs to finish.
+
+  For example:
+
+  with CreateThreadPoolAndWait() as pool:
+    result1=pool.apply_async(func1)
+    result2=pool.apply_async(func2)
+  """
+
+  def __init__(self):
+    self._pool = multiprocessing.pool.ThreadPool()
+
+  def __enter__(self):
+    return self._pool
+
+  def __exit__(self, exc_type, exc_val, exc_tb):
+    self._pool.close()
+    self._pool.join()
+
+
+def invoke_shell(args):
+  """Invokes a shell command."""
+  logging.debug('Executing command: %s', args)
+  child = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  output, _ = child.communicate()
+  exit_code = child.returncode
+  return output, exit_code
+
+
+def get_cookbook_deps(cookbook, knife_binary):
+  """Returns cookbooks dependencies."""
+  if cookbook in _COOKBOOKS:
+    # do not check cookbook twice
+    return _COOKBOOKS[cookbook]
+
+  command = [
+      knife_binary, 'deps', '--config-option',
+      'cookbook_path=%s' % COOKBOOKS_DIR,
+      os.path.join('/cookbooks', cookbook)
+  ]
+  deps, exit_code = invoke_shell(command)
+  assert exit_code == 0, exit_code
+  deps = deps.splitlines()
+
+  _COOKBOOKS[cookbook] = deps
+  return deps
+
+
+def get_solutions_list():
+  """Returns list of solutions."""
+  listdir = [
+      f for f in os.listdir(PACKER_DIR)
+      if os.path.isdir(os.path.join(PACKER_DIR, f))
+  ]
+  listdir.sort()
+  return listdir
+
+
+def generate_config(solution, knife_binary):
+  trigger = VmTriggerConfig(solution=solution, knife_binary=knife_binary)
+  return trigger.generate_config()
+
+
+def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--knife_binary', type=str, default='knife', help='knife-solo binary')
+  args = parser.parse_args()
+
+  listdir = get_solutions_list()
+
+  with CreateThreadPoolAndWait() as pool:
+    triggers_results = [
+        pool.apply_async(generate_config, (solution, args.knife_binary))
+        for solution in listdir
+    ]
+
+  triggers = [result.get() for result in triggers_results]
+
+  print(yaml.dump_all(triggers, default_flow_style=False))
+
+
+if __name__ == '__main__':
+  logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+  os.sys.exit(main())

--- a/scripts/triggers_vm_generator.py
+++ b/scripts/triggers_vm_generator.py
@@ -153,8 +153,7 @@ def get_cookbook_deps(cookbook, knife_binary):
   ]
   deps, exit_code = invoke_shell(command)
   assert exit_code == 0, exit_code
-  deps = deps.splitlines()
-  deps = [x.replace('/cookbooks/', '') for x in deps]
+  deps = [x.replace('/cookbooks/', '') for x in deps.splitlines()]
 
   _COOKBOOKS[cookbook] = deps
   return deps

--- a/scripts/triggers_vm_generator.py
+++ b/scripts/triggers_vm_generator.py
@@ -74,7 +74,7 @@ class VmTriggerConfig(object):
     for cookbook in self.packer_run_list:
       for dep in get_cookbook_deps(
           cookbook=cookbook, knife_binary=self._knife_binary):
-        included_files.append(os.path.join('vm/chef', dep, '**'))
+        included_files.append(os.path.join(COOKBOOKS_DIR, dep, '**'))
 
     included_files = self._remove_duplicates(included_files)
     return included_files
@@ -154,6 +154,7 @@ def get_cookbook_deps(cookbook, knife_binary):
   deps, exit_code = invoke_shell(command)
   assert exit_code == 0, exit_code
   deps = deps.splitlines()
+  deps =  [x.replace('/cookbooks/', '') for x in deps]
 
   _COOKBOOKS[cookbook] = deps
   return deps

--- a/scripts/triggers_vm_generator.py
+++ b/scripts/triggers_vm_generator.py
@@ -154,7 +154,7 @@ def get_cookbook_deps(cookbook, knife_binary):
   deps, exit_code = invoke_shell(command)
   assert exit_code == 0, exit_code
   deps = deps.splitlines()
-  deps =  [x.replace('/cookbooks/', '') for x in deps]
+  deps = [x.replace('/cookbooks/', '') for x in deps]
 
   _COOKBOOKS[cookbook] = deps
   return deps

--- a/scripts/triggers_vm_generator_test.py
+++ b/scripts/triggers_vm_generator_test.py
@@ -56,6 +56,7 @@ class VmTriggerConfigTest(unittest.TestCase):
         solution='wordpress', knife_binary='/bin/bash')
 
   def test_packer_run_list(self):
+    # TODO(wgrzelak): Implement unittest.
     pass
 
   def test_should_include_test(self):
@@ -69,6 +70,7 @@ class VmTriggerConfigTest(unittest.TestCase):
                      self.trigger.tests_dir)
 
   def test_included_files(self):
+    # TODO(wgrzelak): Implement unittest.
     pass
 
   def test_remove_duplicates(self):
@@ -76,6 +78,7 @@ class VmTriggerConfigTest(unittest.TestCase):
                      self.trigger._remove_duplicates(['a', 'a', 'b']))
 
   def test_generate_config(self):
+    # TODO(wgrzelak): Implement unittest.
     pass
 
 

--- a/scripts/triggers_vm_generator_test.py
+++ b/scripts/triggers_vm_generator_test.py
@@ -1,0 +1,83 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+import triggers_vm_generator
+import unittest
+
+
+class CreateThreadPoolAndWaitTest(unittest.TestCase):
+
+  def test_close(self):
+    with self.assertRaises(AssertionError):
+      with triggers_vm_generator.CreateThreadPoolAndWait() as pool:
+        pass
+      pool.apply_async(lambda: True)
+
+  def test_join(self):
+    with triggers_vm_generator.CreateThreadPoolAndWait() as pool:
+      # task takes 3 sec to complete
+      result = pool.apply_async(time.sleep, (3,))
+    self.assertTrue(result.successful())
+
+
+class TriggersVmGeneratorTest(unittest.TestCase):
+
+  def test_invoke_shell(self):
+    self.assertEqual(('1\n', 0),
+                     triggers_vm_generator.invoke_shell(['echo', '1']))
+    self.assertEqual(
+        ('', 0),
+        triggers_vm_generator.invoke_shell(['/bin/bash', '-c', 'exit 0']))
+    self.assertEqual(
+        ('', 1),
+        triggers_vm_generator.invoke_shell(['/bin/bash', '-c', 'exit 1']))
+    self.assertEqual(
+        ('', 2),
+        triggers_vm_generator.invoke_shell(['/bin/bash', '-c', 'exit 2']))
+
+
+class VmTriggerConfigTest(unittest.TestCase):
+
+  def setUp(self):
+    super(VmTriggerConfigTest, self).setUp()
+    self.trigger = triggers_vm_generator.VmTriggerConfig(
+        solution='wordpress', knife_binary='/bin/bash')
+
+  def test_packer_run_list(self):
+    pass
+
+  def test_should_include_test(self):
+    self.assertTrue(self.trigger.should_include_test)
+
+  def test_packer_dir(self):
+    self.assertEqual('vm/packer/templates/wordpress', self.trigger.packer_dir)
+
+  def test_tests_dirr(self):
+    self.assertEqual('vm/tests/solutions/spec/wordpress',
+                     self.trigger.tests_dir)
+
+  def test_included_files(self):
+    pass
+
+  def test_remove_duplicates(self):
+    self.assertEqual(['a', 'b'],
+                     self.trigger._remove_duplicates(['a', 'a', 'b']))
+
+  def test_generate_config(self):
+    pass
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Generates GCB triggers configuration automatically based on Chef's cookbooks dependencies. For now, it will be just printed until triggers as a code are not supported.

Output: https://travis-ci.com/GoogleCloudPlatform/click-to-deploy/jobs/218598730