### PR TITLE
Jmsully cloudsql

### DIFF
--- a/vm/chef/cookbooks/cloudsql/files/cloudsql-proxy.service
+++ b/vm/chef/cookbooks/cloudsql/files/cloudsql-proxy.service
@@ -19,6 +19,6 @@ Type=simple
 WorkingDirectory=/opt/c2d/downloads
 ExecStart=/opt/c2d/downloads/cloudsql-proxy
 StandardOutput=journal
-User=root
+User=cloudsqluser
 [Install]
 WantedBy=multi-user.target

--- a/vm/chef/cookbooks/cloudsql/recipes/default.rb
+++ b/vm/chef/cookbooks/cloudsql/recipes/default.rb
@@ -38,8 +38,13 @@ cookbook_file '/lib/systemd/system/cloudsql-proxy.service' do
   source 'cloudsql-proxy.service'
   owner 'root'
   group 'root'
-  mode 0644
+  mode 06444
   action :create
+end
+
+user 'cloudsqluser' do
+  action :create
+  comment 'Used to start cloudsql serivce'
 end
 
 service 'cloudsql-proxy' do

--- a/vm/chef/cookbooks/cloudsql/recipes/default.rb
+++ b/vm/chef/cookbooks/cloudsql/recipes/default.rb
@@ -38,7 +38,7 @@ cookbook_file '/lib/systemd/system/cloudsql-proxy.service' do
   source 'cloudsql-proxy.service'
   owner 'root'
   group 'root'
-  mode 06444
+  mode 0644
   action :create
 end
 


### PR DESCRIPTION
<!--- /gcbrun -->

**Category:**

- [x] Virtual machines
- [ ] Kubernetes apps
- [ ] Container images

---

<!-- 1. Please select the category from the list above. -->
<!-- 2. Please describe the PR below. -->
When enabling the proxy service as root, unwanted config files were being dropped into /root/.config . By creating a cloudsqluser and using it to start the service, we are about to avoid the association by root.