### PR TITLE
Fixes and improvements to postgresql docs

### DIFF
--- a/k8s/postgresql/README.md
+++ b/k8s/postgresql/README.md
@@ -283,15 +283,15 @@ Forward the port locally:
 ```shell
 kubectl port-forward \
   --namespace "${NAMESPACE}" \
-  "${APP_INSTANCE_NAME}-postgresql-0" 5432
+  "${APP_INSTANCE_NAME}-postgresql-0" 15432:5432
 ```
 
 Sign in to PostgreSQL:
 
 ```shell
-PGPASSWORD=$(kubectl get secret "${APP_INSTANCE_NAME}-secret" --output=jsonpath='{.data.password}' | openssl base64 -d -A)
+PGPASSWORD=$(kubectl get secret "${APP_INSTANCE_NAME}-secret" --output=jsonpath='{.data.password}' --namespace "${NAMESPACE}" | openssl base64 -d -A)
 
-echo PGPASSWORD=$PGPASSWORD sslmode=require psql -U postgres -h 127.0.0.1
+PGPASSWORD=$PGPASSWORD sslmode=require psql -U postgres -h 127.0.0.1 -p 15432
 ```
 
 # Application metrics


### PR DESCRIPTION
**Category:**

- [x] Kubernetes apps

Fixed the following problems:

* Reading the postgres admin secret didn't specify the namespace
* The command to connect to postgres as the admin user just echoed

Made the following improvement:

* If you're the sort of person that is running and connecting to postgres on a GKE cluster, there's a high chance that you're also the sort of person who is running postgres locally on your machine. So binding the port forward to 5432 locally is not going to work (and will usually fail silently, since by default postgres binds to localhost, but the kubectl port-forward command by default binds to 0:0:0:0, so port forwarding will succeed, it's just that when you try to connect to localhost:5432, you'll get your local postgres instance, and authentication will fail). So I changed it to port forward 15432:5432, and then connect to localhost:15432. This should work for most people.