### PR TITLE
Unify make rules in common Makefile

### DIFF
--- a/k8s/app_v2.Makefile
+++ b/k8s/app_v2.Makefile
@@ -13,8 +13,21 @@ include $(makefile_dir)/var.Makefile
 
 VERIFY_WAIT_TIMEOUT = 600
 
+##### Common variables #####
+APP_DEPLOYER_IMAGE ?= $(REGISTRY)/$(APP_ID)/deployer:$(RELEASE)
+APP_DEPLOYER_IMAGE_TRACK_TAG ?= $(REGISTRY)/$(APP_ID)/deployer:$(TRACK)
+TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
+APP_GCS_PATH ?= $(GCS_URL)/$(APP_ID)/$(TRACK)
+
+SOURCE_REGISTRY ?= marketplace.gcr.io/google
+
 ##### Validations and Information #####
 
+ifndef APP_ID
+$(error APP_ID must be defined)
+endif
+
+$(info ---- APP_ID = $(APP_ID))
 
 ifndef APP_GCS_PATH
 $(error APP_GCS_PATH must be defined)
@@ -27,6 +40,11 @@ $(error APP_DEPLOYER_IMAGE must be defined)
 endif
 
 $(info ---- APP_DEPLOYER_IMAGE = $(APP_DEPLOYER_IMAGE))
+
+$(info ---- TRACK = $(TRACK))
+$(info ---- RELEASE = $(RELEASE))
+$(info ---- APP IMAGE = $(image-$(APP_ID)))
+
 
 ##### Helper functions #####
 
@@ -64,6 +82,76 @@ endef
 	    cat /scripts/dev > "/tmp/dev"
 	@mv "/tmp/dev" "$@"
 	@chmod a+x "$@"
+
+
+.PHONY: images $(APP_ID)
+images: $(TARGETS)
+
+app/build:: .build/$(APP_ID)/deployer \
+            $(APP_ID) \
+            images \
+            .build/$(APP_ID)/tester \
+            .build/$(APP_ID)/VERSION
+
+
+.build/$(APP_ID): | .build
+	mkdir -p "$@"
+
+
+.build/$(APP_ID)/deployer: deployer/* \
+                           chart/$(APP_ID)/* \
+                           chart/$(APP_ID)/templates/* \
+                           schema.yaml \
+                           .build/var/APP_DEPLOYER_IMAGE \
+                           .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
+                           .build/var/MARKETPLACE_TOOLS_TAG \
+                           .build/var/REGISTRY \
+                           .build/var/TRACK \
+                           .build/var/RELEASE \
+                           | .build/$(APP_ID)
+	docker build \
+		--build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
+		--build-arg TAG="$(RELEASE)" \
+		--build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
+		--tag "$(APP_DEPLOYER_IMAGE)" \
+		-f deployer/Dockerfile \
+		.
+	docker tag "$(APP_DEPLOYER_IMAGE)" "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
+	docker push "$(APP_DEPLOYER_IMAGE)"
+	docker push "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
+	@touch "$@"
+
+
+$(APP_ID): .build/var/REGISTRY \
+           .build/var/TRACK \
+           .build/var/RELEASE \
+           | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$@:$(RELEASE)"
+
+
+$(TARGETS): .build/var/REGISTRY \
+            .build/var/TRACK \
+            .build/var/RELEASE \
+            | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+
+
+.build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \
+                              $(shell find apptest -type f) \
+                              | .build/$(APP_ID)
+	$(call print_target,$@)
+	cd apptest/tester \
+		&& docker build --tag "$(TESTER_IMAGE)" .
+	docker push "$(TESTER_IMAGE)"
+	@touch "$@"
 
 
 ########### Main  targets ###########

--- a/k8s/app_v2.Makefile
+++ b/k8s/app_v2.Makefile
@@ -84,14 +84,14 @@ endef
 	@chmod a+x "$@"
 
 
-.PHONY: images $(APP_ID)
-images: $(TARGETS)
-
-app/build:: .build/$(APP_ID)/deployer \
-            $(APP_ID) \
-            images \
+app/build:: $(APP_ID) \
+            .build/$(APP_ID)/deployer \
+            .build/images \
             .build/$(APP_ID)/tester \
             .build/$(APP_ID)/VERSION
+
+
+.build/images: $(TARGETS)
 
 
 .build/$(APP_ID): | .build
@@ -122,6 +122,7 @@ app/build:: .build/$(APP_ID)/deployer \
 	@touch "$@"
 
 
+.PHONY: $(APP_ID)
 $(APP_ID): .build/var/REGISTRY \
            .build/var/TRACK \
            .build/var/RELEASE \

--- a/k8s/app_v2_1.Makefile
+++ b/k8s/app_v2_1.Makefile
@@ -91,7 +91,7 @@ app/build:: $(APP_ID) \
             .build/$(APP_ID)/VERSION
 
 
-.build/images: $(TARGETS)
+.build/images: $(TARGET_IMAGES)
 
 
 .build/$(APP_ID): | .build
@@ -134,7 +134,7 @@ $(APP_ID): .build/var/REGISTRY \
 	docker push "$(REGISTRY)/$@:$(RELEASE)"
 
 
-$(TARGETS): .build/var/REGISTRY \
+$(TARGET_IMAGES): .build/var/REGISTRY \
             .build/var/TRACK \
             .build/var/RELEASE \
             | .build/$(APP_ID)

--- a/k8s/app_v2_1.Makefile
+++ b/k8s/app_v2_1.Makefile
@@ -13,8 +13,21 @@ include $(makefile_dir)/var.Makefile
 
 VERIFY_WAIT_TIMEOUT = 600
 
+##### Common variables #####
+APP_DEPLOYER_IMAGE ?= $(REGISTRY)/$(APP_ID)/deployer:$(RELEASE)
+APP_DEPLOYER_IMAGE_TRACK_TAG ?= $(REGISTRY)/$(APP_ID)/deployer:$(TRACK)
+TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
+APP_GCS_PATH ?= $(GCS_URL)/$(APP_ID)/$(TRACK)
+
+SOURCE_REGISTRY ?= marketplace.gcr.io/google
+
 ##### Validations and Information #####
 
+ifndef APP_ID
+$(error APP_ID must be defined)
+endif
+
+$(info ---- APP_ID = $(APP_ID))
 
 ifndef APP_GCS_PATH
 $(error APP_GCS_PATH must be defined)
@@ -27,6 +40,11 @@ $(error APP_DEPLOYER_IMAGE must be defined)
 endif
 
 $(info ---- APP_DEPLOYER_IMAGE = $(APP_DEPLOYER_IMAGE))
+
+$(info ---- TRACK = $(TRACK))
+$(info ---- RELEASE = $(RELEASE))
+$(info ---- APP IMAGE = $(image-$(APP_ID)))
+
 
 ##### Helper functions #####
 
@@ -64,6 +82,77 @@ endef
 	    cat /scripts/dev > "/tmp/dev"
 	@mv "/tmp/dev" "$@"
 	@chmod a+x "$@"
+
+
+app/build:: $(APP_ID) \
+            .build/$(APP_ID)/deployer \
+            .build/images \
+            .build/$(APP_ID)/tester \
+            .build/$(APP_ID)/VERSION
+
+
+.build/images: $(TARGETS)
+
+
+.build/$(APP_ID): | .build
+	mkdir -p "$@"
+
+
+.build/$(APP_ID)/deployer: deployer/* \
+                           chart/$(APP_ID)/* \
+                           chart/$(APP_ID)/templates/* \
+                           schema.yaml \
+                           .build/var/APP_DEPLOYER_IMAGE \
+                           .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
+                           .build/var/MARKETPLACE_TOOLS_TAG \
+                           .build/var/REGISTRY \
+                           .build/var/TRACK \
+                           .build/var/RELEASE \
+                           | .build/$(APP_ID)
+	docker build \
+		--build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
+		--build-arg TAG="$(RELEASE)" \
+		--build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
+		--tag "$(APP_DEPLOYER_IMAGE)" \
+		-f deployer/Dockerfile \
+		.
+	docker tag "$(APP_DEPLOYER_IMAGE)" "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
+	docker push "$(APP_DEPLOYER_IMAGE)"
+	docker push "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
+	@touch "$@"
+
+
+.PHONY: $(APP_ID)
+$(APP_ID): .build/var/REGISTRY \
+           .build/var/TRACK \
+           .build/var/RELEASE \
+           | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$@:$(RELEASE)"
+
+
+$(TARGETS): .build/var/REGISTRY \
+            .build/var/TRACK \
+            .build/var/RELEASE \
+            | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+
+
+.build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \
+                              $(shell find apptest -type f) \
+                              | .build/$(APP_ID)
+	$(call print_target,$@)
+	cd apptest/tester \
+		&& docker build --tag "$(TESTER_IMAGE)" .
+	docker push "$(TESTER_IMAGE)"
+	@touch "$@"
 
 
 ########### Main  targets ###########

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -53,12 +53,13 @@ APP_PARAMETERS ?= { \
 # must be included after.
 include ../app_v2.Makefile
 
-.PHONY: images
-TARGETS := $(APP_ID) mysqld-exporter prometheus-to-sd peer-finder
+.PHONY: images $(APP_ID)
+TARGETS := mysqld-exporter prometheus-to-sd peer-finder
 
 images: $(TARGETS)
 
 app/build:: .build/$(APP_ID)/deployer \
+            $(APP_ID) \
             images \
             .build/$(APP_ID)/tester \
             .build/$(APP_ID)/VERSION
@@ -75,33 +76,33 @@ app/build:: .build/$(APP_ID)/deployer \
 
 
 .build/$(APP_ID)/deployer: deployer/* \
-                                chart/$(APP_ID)/* \
-                                chart/$(APP_ID)/templates/* \
-                                schema.yaml \
-                                .build/var/APP_DEPLOYER_IMAGE \
-                                .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
-                                .build/var/MARKETPLACE_TOOLS_TAG \
-                                .build/var/REGISTRY \
-                                .build/var/TRACK \
-                                .build/var/RELEASE \
-                                | .build/$(APP_ID)
+                           chart/$(APP_ID)/* \
+                           chart/$(APP_ID)/templates/* \
+                           schema.yaml \
+                           .build/var/APP_DEPLOYER_IMAGE \
+                           .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
+                           .build/var/MARKETPLACE_TOOLS_TAG \
+                           .build/var/REGISTRY \
+                           .build/var/TRACK \
+                           .build/var/RELEASE \
+                           | .build/$(APP_ID)
 	docker build \
-	    --build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
-	    --build-arg TAG="$(RELEASE)" \
-	    --build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
-	    --tag "$(APP_DEPLOYER_IMAGE)" \
-	    -f deployer/Dockerfile \
-	    .
+		--build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
+		--build-arg TAG="$(RELEASE)" \
+		--build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
+		--tag "$(APP_DEPLOYER_IMAGE)" \
+		-f deployer/Dockerfile \
+		.
 	docker tag "$(APP_DEPLOYER_IMAGE)" "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
 	docker push "$(APP_DEPLOYER_IMAGE)"
 	docker push "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
 	@touch "$@"
 
 
-$(TARGETS): .build/var/REGISTRY \
-            .build/var/TRACK \
-            .build/var/RELEASE \
-            | .build/$(APP_ID)
+$(APP_ID): .build/var/REGISTRY \
+           .build/var/TRACK \
+           .build/var/RELEASE \
+           | .build/$(APP_ID)
 	docker pull $(image-$@)
 	docker tag $(image-$@) "$(REGISTRY)/$@:$(TRACK)"
 	docker tag $(image-$@) "$(REGISTRY)/$@:$(RELEASE)"
@@ -109,11 +110,22 @@ $(TARGETS): .build/var/REGISTRY \
 	docker push "$(REGISTRY)/$@:$(RELEASE)"
 
 
+$(TARGETS): .build/var/REGISTRY \
+            .build/var/TRACK \
+            .build/var/RELEASE \
+            | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
+
+
 .build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \
                               $(shell find apptest -type f) \
                               | .build/$(APP_ID)
 	$(call print_target,$@)
 	cd apptest/tester \
-	    && docker build --tag "$(TESTER_IMAGE)" .
+		&& docker build --tag "$(TESTER_IMAGE)" .
 	docker push "$(TESTER_IMAGE)"
 	@touch "$@"

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -25,7 +25,6 @@ image-mysqld-exporter ?= $(SOURCE_REGISTRY)/mysql5:exporter
 image-peer-finder ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)
 image-prometheus-to-sd ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
-
 # Additional variables
 ifdef METRICS_EXPORTER_ENABLED
   METRICS_EXPORTER_ENABLED_FIELD = , "prometheusToSd.enabled": $(METRICS_EXPORTER_ENABLED)
@@ -42,7 +41,7 @@ APP_PARAMETERS ?= { \
 # application.
 # It requires several APP_* variables defined above, and thus
 # must be included after.
-include ../app_v2.Makefile
+include ../app_v2_2.Makefile
 
 .PHONY: .build/$(APP_ID)/VERSION
 .build/$(APP_ID)/VERSION:

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -26,10 +26,10 @@ SOURCE_REGISTRY ?= marketplace.gcr.io/google
 # ===== end to move =====
 
 # Images
-IMAGE_MARIADB ?= $(SOURCE_REGISTRY)/mariadb10@$(MARIADB_TAG)
-IMAGE_MARIADB_EXPORTER ?= $(SOURCE_REGISTRY)/mysql5:exporter
-IMAGE_PEER_FINDER ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)
-IMAGE_PROMETHEUS_TO_SD ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
+image-$(APP_ID) ?= $(SOURCE_REGISTRY)/mariadb10@$(MARIADB_TAG)
+image-mysqld-exporter ?= $(SOURCE_REGISTRY)/mysql5:exporter
+image-peer-finder ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)
+image-prometheus-to-sd ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
 # Additional variables
 ifdef METRICS_EXPORTER_ENABLED
@@ -53,11 +53,13 @@ APP_PARAMETERS ?= { \
 # must be included after.
 include ../app_v2.Makefile
 
+.PHONY: images
+TARGETS := $(APP_ID) mysqld-exporter prometheus-to-sd peer-finder
+
+images: $(TARGETS)
+
 app/build:: .build/$(APP_ID)/deployer \
-            .build/$(APP_ID)/$(APP_ID) \
-            .build/$(APP_ID)/mysqld-exporter \
-            .build/$(APP_ID)/prometheus-to-sd \
-            .build/$(APP_ID)/peer-finder \
+            images \
             .build/$(APP_ID)/tester \
             .build/$(APP_ID)/VERSION
 
@@ -96,59 +98,15 @@ app/build:: .build/$(APP_ID)/deployer \
 	@touch "$@"
 
 
-.build/$(APP_ID)/$(APP_ID): .build/var/REGISTRY \
-                                      .build/var/TRACK \
-                                      .build/var/RELEASE \
-                                      | .build/$(APP_ID)
-	docker pull $(IMAGE_MARIADB)
-	docker tag $(IMAGE_MARIADB) "$(REGISTRY)/$(APP_ID):$(TRACK)"
-	docker tag "$(REGISTRY)/$(APP_ID):$(TRACK)" \
-	    "$(REGISTRY)/$(APP_ID):$(RELEASE)"
-	docker push "$(REGISTRY)/$(APP_ID):$(TRACK)"
-	docker push "$(REGISTRY)/$(APP_ID):$(RELEASE)"
-	@touch "$@"
-
-
-.build/$(APP_ID)/mysqld-exporter: .build/var/REGISTRY \
-                                       .build/var/TRACK \
-                                       .build/var/RELEASE \
-                                       | .build/$(APP_ID)
-	docker pull $(IMAGE_MARIADB_EXPORTER)
-	docker tag $(IMAGE_MARIADB_EXPORTER) \
-	    "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(TRACK)"
-	docker tag "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(TRACK)" \
-	    "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(RELEASE)"
-	docker push "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(TRACK)"
-	docker push "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(RELEASE)"
-	@touch "$@"
-
-
-.build/$(APP_ID)/prometheus-to-sd: .build/var/REGISTRY \
-                                        .build/var/TRACK \
-                                        .build/var/RELEASE \
-                                        | .build/$(APP_ID)
-	docker pull $(IMAGE_PROMETHEUS_TO_SD)
-	docker tag $(IMAGE_PROMETHEUS_TO_SD) \
-	    "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(TRACK)"
-	docker tag "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(TRACK)" \
-	    "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(RELEASE)"
-	docker push "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(TRACK)"
-	docker push "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(RELEASE)"
-	@touch "$@"
-
-
-.build/$(APP_ID)/peer-finder: .build/var/REGISTRY \
-                                   .build/var/TRACK \
-                                   .build/var/RELEASE \
-                                   | .build/$(APP_ID)
-	docker pull $(IMAGE_PEER_FINDER)
-	docker tag $(IMAGE_PEER_FINDER) \
-	    "$(REGISTRY)/$(APP_ID)/peer-finder:$(TRACK)"
-	docker tag "$(REGISTRY)/$(APP_ID)/peer-finder:$(TRACK)" \
-	    "$(REGISTRY)/$(APP_ID)/peer-finder:$(RELEASE)"
-	docker push "$(REGISTRY)/$(APP_ID)/peer-finder:$(TRACK)"
-	docker push "$(REGISTRY)/$(APP_ID)/peer-finder:$(RELEASE)"
-	@touch "$@"
+$(TARGETS): .build/var/REGISTRY \
+            .build/var/TRACK \
+            .build/var/RELEASE \
+            | .build/$(APP_ID)
+	docker pull $(image-$@)
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(TRACK)"
+	docker tag $(image-$@) "$(REGISTRY)/$@:$(RELEASE)"
+	docker push "$(REGISTRY)/$@:$(TRACK)"
+	docker push "$(REGISTRY)/$@:$(RELEASE)"
 
 
 .build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -41,7 +41,7 @@ APP_PARAMETERS ?= { \
 # application.
 # It requires several APP_* variables defined above, and thus
 # must be included after.
-include ../app_v2_2.Makefile
+include ../app_v2_1.Makefile
 
 .PHONY: .build/$(APP_ID)/VERSION
 .build/$(APP_ID)/VERSION:

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -16,32 +16,36 @@ BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 10.3
 RELEASE ?= 10.3.17-$(BUILD_ID)
 
-$(info ---- TRACK = $(TRACK))
-$(info ---- RELEASE = $(RELEASE))
-
+# ===== to move =====
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/$(APP_ID)/deployer:$(RELEASE)
 APP_DEPLOYER_IMAGE_TRACK_TAG ?= $(REGISTRY)/$(APP_ID)/deployer:$(TRACK)
+TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
 APP_GCS_PATH ?= $(GCS_URL)/$(APP_ID)/$(TRACK)
 
-NAME ?= $(APP_ID)-1
-
 SOURCE_REGISTRY ?= marketplace.gcr.io/google
+# ===== end to move =====
+
+# Images
 IMAGE_MARIADB ?= $(SOURCE_REGISTRY)/mariadb10@$(MARIADB_TAG)
 IMAGE_MARIADB_EXPORTER ?= $(SOURCE_REGISTRY)/mysql5:exporter
 IMAGE_PEER_FINDER ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)
 IMAGE_PROMETHEUS_TO_SD ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
+# Additional variables
 ifdef METRICS_EXPORTER_ENABLED
   METRICS_EXPORTER_ENABLED_FIELD = , "prometheusToSd.enabled": $(METRICS_EXPORTER_ENABLED)
 endif
 
+$(info ---- TRACK = $(TRACK))
+$(info ---- RELEASE = $(RELEASE))
+$(info ---- APP IMAGE = $(IMAGE_MARIADB))
+
+NAME ?= $(APP_ID)-1
 APP_PARAMETERS ?= { \
   "name": "$(NAME)", \
   "namespace": "$(NAMESPACE)" \
   $(METRICS_EXPORTER_ENABLED_FIELD) \
 }
-
-TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
 
 # app_v2.Makefile provides the main targets for installing the
 # application.
@@ -49,28 +53,28 @@ TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
 # must be included after.
 include ../app_v2.Makefile
 
-app/build:: .build/mariadb-galera/deployer \
-            .build/mariadb-galera/mariadb-galera \
-            .build/mariadb-galera/mysqld-exporter \
-            .build/mariadb-galera/prometheus-to-sd \
-            .build/mariadb-galera/peer-finder \
-            .build/mariadb-galera/tester \
-            .build/mariadb-galera/VERSION
+app/build:: .build/$(APP_ID)/deployer \
+            .build/$(APP_ID)/$(APP_ID) \
+            .build/$(APP_ID)/mysqld-exporter \
+            .build/$(APP_ID)/prometheus-to-sd \
+            .build/$(APP_ID)/peer-finder \
+            .build/$(APP_ID)/tester \
+            .build/$(APP_ID)/VERSION
 
 
-.build/mariadb-galera: | .build
+.build/$(APP_ID): | .build
 	mkdir -p "$@"
 
 
-.PHONY: .build/mariadb-galera/VERSION
-.build/mariadb-galera/VERSION:
+.PHONY: .build/$(APP_ID)/VERSION
+.build/$(APP_ID)/VERSION:
 	docker run --rm --entrypoint=printenv $(IMAGE_MARIADB) MARIADB_VERSION \
 	    | awk -F'[+:]' '{ print $$2 }'
 
 
-.build/mariadb-galera/deployer: deployer/* \
-                                chart/mariadb-galera/* \
-                                chart/mariadb-galera/templates/* \
+.build/$(APP_ID)/deployer: deployer/* \
+                                chart/$(APP_ID)/* \
+                                chart/$(APP_ID)/templates/* \
                                 schema.yaml \
                                 .build/var/APP_DEPLOYER_IMAGE \
                                 .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
@@ -78,7 +82,7 @@ app/build:: .build/mariadb-galera/deployer \
                                 .build/var/REGISTRY \
                                 .build/var/TRACK \
                                 .build/var/RELEASE \
-                                | .build/mariadb-galera
+                                | .build/$(APP_ID)
 	docker build \
 	    --build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
 	    --build-arg TAG="$(RELEASE)" \
@@ -92,10 +96,10 @@ app/build:: .build/mariadb-galera/deployer \
 	@touch "$@"
 
 
-.build/mariadb-galera/mariadb-galera: .build/var/REGISTRY \
+.build/$(APP_ID)/$(APP_ID): .build/var/REGISTRY \
                                       .build/var/TRACK \
                                       .build/var/RELEASE \
-                                      | .build/mariadb-galera
+                                      | .build/$(APP_ID)
 	docker pull $(IMAGE_MARIADB)
 	docker tag $(IMAGE_MARIADB) "$(REGISTRY)/$(APP_ID):$(TRACK)"
 	docker tag "$(REGISTRY)/$(APP_ID):$(TRACK)" \
@@ -105,10 +109,10 @@ app/build:: .build/mariadb-galera/deployer \
 	@touch "$@"
 
 
-.build/mariadb-galera/mysqld-exporter: .build/var/REGISTRY \
+.build/$(APP_ID)/mysqld-exporter: .build/var/REGISTRY \
                                        .build/var/TRACK \
                                        .build/var/RELEASE \
-                                       | .build/mariadb-galera
+                                       | .build/$(APP_ID)
 	docker pull $(IMAGE_MARIADB_EXPORTER)
 	docker tag $(IMAGE_MARIADB_EXPORTER) \
 	    "$(REGISTRY)/$(APP_ID)/mysqld-exporter:$(TRACK)"
@@ -119,10 +123,10 @@ app/build:: .build/mariadb-galera/deployer \
 	@touch "$@"
 
 
-.build/mariadb-galera/prometheus-to-sd: .build/var/REGISTRY \
+.build/$(APP_ID)/prometheus-to-sd: .build/var/REGISTRY \
                                         .build/var/TRACK \
                                         .build/var/RELEASE \
-                                        | .build/mariadb-galera
+                                        | .build/$(APP_ID)
 	docker pull $(IMAGE_PROMETHEUS_TO_SD)
 	docker tag $(IMAGE_PROMETHEUS_TO_SD) \
 	    "$(REGISTRY)/$(APP_ID)/prometheus-to-sd:$(TRACK)"
@@ -133,10 +137,10 @@ app/build:: .build/mariadb-galera/deployer \
 	@touch "$@"
 
 
-.build/mariadb-galera/peer-finder: .build/var/REGISTRY \
+.build/$(APP_ID)/peer-finder: .build/var/REGISTRY \
                                    .build/var/TRACK \
                                    .build/var/RELEASE \
-                                   | .build/mariadb-galera
+                                   | .build/$(APP_ID)
 	docker pull $(IMAGE_PEER_FINDER)
 	docker tag $(IMAGE_PEER_FINDER) \
 	    "$(REGISTRY)/$(APP_ID)/peer-finder:$(TRACK)"
@@ -147,9 +151,9 @@ app/build:: .build/mariadb-galera/deployer \
 	@touch "$@"
 
 
-.build/mariadb-galera/tester: .build/var/TESTER_IMAGE \
+.build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \
                               $(shell find apptest -type f) \
-                              | .build/mariadb-galera
+                              | .build/$(APP_ID)
 	$(call print_target,$@)
 	cd apptest/tester \
 	    && docker build --tag "$(TESTER_IMAGE)" .

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -16,10 +16,10 @@ BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 10.3
 RELEASE ?= 10.3.17-$(BUILD_ID)
 
-TARGETS := mysqld-exporter prometheus-to-sd peer-finder
+# List of images used in application
+TARGET_IMAGES := mysqld-exporter prometheus-to-sd peer-finder
 
-
-# Images
+# Image names should correspond with TARGET_IMAGES list
 image-$(APP_ID) ?= $(SOURCE_REGISTRY)/mariadb10@$(MARIADB_TAG)
 image-mysqld-exporter ?= $(SOURCE_REGISTRY)/mysql5:exporter
 image-peer-finder ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)

--- a/k8s/mariadb-galera/Makefile
+++ b/k8s/mariadb-galera/Makefile
@@ -16,14 +16,8 @@ BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 10.3
 RELEASE ?= 10.3.17-$(BUILD_ID)
 
-# ===== to move =====
-APP_DEPLOYER_IMAGE ?= $(REGISTRY)/$(APP_ID)/deployer:$(RELEASE)
-APP_DEPLOYER_IMAGE_TRACK_TAG ?= $(REGISTRY)/$(APP_ID)/deployer:$(TRACK)
-TESTER_IMAGE ?= $(REGISTRY)/$(APP_ID)/tester:$(RELEASE)
-APP_GCS_PATH ?= $(GCS_URL)/$(APP_ID)/$(TRACK)
+TARGETS := mysqld-exporter prometheus-to-sd peer-finder
 
-SOURCE_REGISTRY ?= marketplace.gcr.io/google
-# ===== end to move =====
 
 # Images
 image-$(APP_ID) ?= $(SOURCE_REGISTRY)/mariadb10@$(MARIADB_TAG)
@@ -31,14 +25,11 @@ image-mysqld-exporter ?= $(SOURCE_REGISTRY)/mysql5:exporter
 image-peer-finder ?= $(SOURCE_REGISTRY)/peer-finder0:$(PEER_FINDER_TAG)
 image-prometheus-to-sd ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
+
 # Additional variables
 ifdef METRICS_EXPORTER_ENABLED
   METRICS_EXPORTER_ENABLED_FIELD = , "prometheusToSd.enabled": $(METRICS_EXPORTER_ENABLED)
 endif
-
-$(info ---- TRACK = $(TRACK))
-$(info ---- RELEASE = $(RELEASE))
-$(info ---- APP IMAGE = $(IMAGE_MARIADB))
 
 NAME ?= $(APP_ID)-1
 APP_PARAMETERS ?= { \
@@ -53,79 +44,7 @@ APP_PARAMETERS ?= { \
 # must be included after.
 include ../app_v2.Makefile
 
-.PHONY: images $(APP_ID)
-TARGETS := mysqld-exporter prometheus-to-sd peer-finder
-
-images: $(TARGETS)
-
-app/build:: .build/$(APP_ID)/deployer \
-            $(APP_ID) \
-            images \
-            .build/$(APP_ID)/tester \
-            .build/$(APP_ID)/VERSION
-
-
-.build/$(APP_ID): | .build
-	mkdir -p "$@"
-
-
 .PHONY: .build/$(APP_ID)/VERSION
 .build/$(APP_ID)/VERSION:
 	docker run --rm --entrypoint=printenv $(IMAGE_MARIADB) MARIADB_VERSION \
 	    | awk -F'[+:]' '{ print $$2 }'
-
-
-.build/$(APP_ID)/deployer: deployer/* \
-                           chart/$(APP_ID)/* \
-                           chart/$(APP_ID)/templates/* \
-                           schema.yaml \
-                           .build/var/APP_DEPLOYER_IMAGE \
-                           .build/var/APP_DEPLOYER_IMAGE_TRACK_TAG \
-                           .build/var/MARKETPLACE_TOOLS_TAG \
-                           .build/var/REGISTRY \
-                           .build/var/TRACK \
-                           .build/var/RELEASE \
-                           | .build/$(APP_ID)
-	docker build \
-		--build-arg REGISTRY="$(REGISTRY)/$(APP_ID)" \
-		--build-arg TAG="$(RELEASE)" \
-		--build-arg MARKETPLACE_TOOLS_TAG="$(MARKETPLACE_TOOLS_TAG)" \
-		--tag "$(APP_DEPLOYER_IMAGE)" \
-		-f deployer/Dockerfile \
-		.
-	docker tag "$(APP_DEPLOYER_IMAGE)" "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
-	docker push "$(APP_DEPLOYER_IMAGE)"
-	docker push "$(APP_DEPLOYER_IMAGE_TRACK_TAG)"
-	@touch "$@"
-
-
-$(APP_ID): .build/var/REGISTRY \
-           .build/var/TRACK \
-           .build/var/RELEASE \
-           | .build/$(APP_ID)
-	docker pull $(image-$@)
-	docker tag $(image-$@) "$(REGISTRY)/$@:$(TRACK)"
-	docker tag $(image-$@) "$(REGISTRY)/$@:$(RELEASE)"
-	docker push "$(REGISTRY)/$@:$(TRACK)"
-	docker push "$(REGISTRY)/$@:$(RELEASE)"
-
-
-$(TARGETS): .build/var/REGISTRY \
-            .build/var/TRACK \
-            .build/var/RELEASE \
-            | .build/$(APP_ID)
-	docker pull $(image-$@)
-	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
-	docker tag $(image-$@) "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
-	docker push "$(REGISTRY)/$(APP_ID)/$@:$(TRACK)"
-	docker push "$(REGISTRY)/$(APP_ID)/$@:$(RELEASE)"
-
-
-.build/$(APP_ID)/tester: .build/var/TESTER_IMAGE \
-                              $(shell find apptest -type f) \
-                              | .build/$(APP_ID)
-	$(call print_target,$@)
-	cd apptest/tester \
-		&& docker build --tag "$(TESTER_IMAGE)" .
-	docker push "$(TESTER_IMAGE)"
-	@touch "$@"


### PR DESCRIPTION
/gcbrun

**Category:**

- [ ] Virtual machines
- [x] Kubernetes apps
- [ ] Container images

---

Refactored Makefiles and moved redundant common rules from solution specific Makefile to app_v2_1.Makefile.

This POC is only for mariadb solution. Once design will be approved changes will be applied to all solutions.