### PR TITLE
Release 13.09.2019

### DIFF
--- a/k8s/cassandra/Makefile
+++ b/k8s/cassandra/Makefile
@@ -8,7 +8,7 @@ VERIFY_WAIT_TIMEOUT = 1800
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/cassandra/VERSION` target to fill the RELEASE variable.
-CASSANDRA_TAG ?= sha256:9123711bcc4fbbcae52d02013b1e8a87e4596d0cc933782ad74dd850d4ecf6e1
+CASSANDRA_TAG ?= sha256:38f4a15b2c6ee559c30d167becbfb2ba8e6ccd476c36a2154a88e12824a7fcf0
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/elastic-gke-logging/Makefile
+++ b/k8s/elastic-gke-logging/Makefile
@@ -8,7 +8,7 @@ VERIFY_WAIT_TIMEOUT = 1200
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/elastic-gke-logging/VERSION` target to fill the RELEASE variable.
-ELASTICSEARCH_TAG ?= sha256:b6714c74389da49ab142bbc3ea2b9db64f046f1c0cffd59e1537183fc33d9561
+ELASTICSEARCH_TAG ?= sha256:077358140de4b64030d37fbd02d5217b5953dff5bc08bf2352dd5ae90b536978
 KIBANA_TAG ?= 6.3
 FLUENTD_TAG ?= 1.2
 METRICS_EXPORTER_TAG ?= v0.5.1

--- a/k8s/elasticsearch/Makefile
+++ b/k8s/elasticsearch/Makefile
@@ -7,7 +7,7 @@ APP_ID ?= elasticsearch-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/elasticsearch/VERSION` target to fill the RELEASE variable.
-ELASTICSEARCH_TAG ?= sha256:b040840b3dde56c44396710f7e52d00eeec56db4b0d9476369eceb20f9575672
+ELASTICSEARCH_TAG ?= sha256:077358140de4b64030d37fbd02d5217b5953dff5bc08bf2352dd5ae90b536978
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/grafana/Makefile
+++ b/k8s/grafana/Makefile
@@ -7,7 +7,7 @@ APP_ID ?= grafana-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/grafana/VERSION` target to fill the RELEASE variable.
-GRAFANA_TAG ?= sha256:2d61c53e58b27e59cd77c9899208bfa31a2d12d27822a3cc3ef362213141a406
+GRAFANA_TAG ?= sha256:987e44b3425d4e80061b7a33ace1bc3a9575f033e017e5b3f48144b39d228811
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/influxdb/Makefile
+++ b/k8s/influxdb/Makefile
@@ -7,12 +7,12 @@ APP_ID ?= influxdb-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/influxdb/VERSION` target to fill the RELEASE variable.
-INFLUXDB_TAG ?= sha256:a41d33e302e917764d10f58dee6e7b89d764045468a30fa9eb31f5cb2c3bd6a8
+INFLUXDB_TAG ?= sha256:ddacedb0bc277d2359eef41a7f0ae3f29918876974815a5197ddd44377ffb12a
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 1.7
-RELEASE ?= 1.7.6-$(BUILD_ID)
+RELEASE ?= 1.7.7-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))

--- a/k8s/jenkins/Makefile
+++ b/k8s/jenkins/Makefile
@@ -8,11 +8,11 @@ VERIFY_WAIT_TIMEOUT = 1800
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/jenkins/VERSION` target to fill the RELEASE variable.
-JENKINS_TAG ?= sha256:57037c8bcdb148890ca3faa4b66dc5a6487ac64d8383f210444e731eefe4a2ea
+JENKINS_TAG ?= sha256:87f38f32fd9bed856934144bed9bfd16d4a624c5a1504e808bf1532de564c571
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 2.176
-RELEASE ?= 2.176.1-$(BUILD_ID)
+RELEASE ?= 2.176.3-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))

--- a/k8s/mariadb/Makefile
+++ b/k8s/mariadb/Makefile
@@ -12,7 +12,7 @@ METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 10.3
-RELEASE ?= 10.3.18-$(BUILD_ID)
+RELEASE ?= 10.3.17-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))

--- a/k8s/mariadb/Makefile
+++ b/k8s/mariadb/Makefile
@@ -7,12 +7,12 @@ APP_ID ?= mariadb-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/mariadb/VERSION` target to fill the RELEASE variable.
-MARIADB_TAG ?= sha256:edc02d0c232098d9882eed8cacfdde63deb7be631894a9323d9471990890b3df
+MARIADB_TAG ?= sha256:0e3b4b07db1b583cea157671b43c83f3c84204c40ae0c91cdda2ad520f326f15
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 10.3
-RELEASE ?= 10.3.15-$(BUILD_ID)
+RELEASE ?= 10.3.18-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))

--- a/k8s/memcached/Makefile
+++ b/k8s/memcached/Makefile
@@ -7,7 +7,7 @@ APP_ID ?= memcached-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/memcached/VERSION` target to fill the RELEASE variable.
-MEMCACHED_TAG ?= sha256:aa0e9c7a68848cb9b226640f426a53cd4a2a8d4c98991fc87cfbfb0ac9725f8f
+MEMCACHED_TAG ?= sha256:a81eb58ec89cef45e167060f4621b0694f2658ee0944c96f67ba950cab5cda1e
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/nginx/Makefile
+++ b/k8s/nginx/Makefile
@@ -7,7 +7,7 @@ APP_ID ?= nginx-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/nginx/VERSION` target to fill the RELEASE variable.
-NGINX_TAG ?= sha256:9de3c4073abb456b8f08d283b886cddf23031f6f8e5db1dc4dcfdf5a19580e5b
+NGINX_TAG ?= sha256:c797f96cf1529764cf8674a757d4f85e20f410912380ed446f3f032f5edb29a3
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/postgresql/Makefile
+++ b/k8s/postgresql/Makefile
@@ -7,12 +7,12 @@ APP_ID ?= postgresql-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/postgresql/VERSION` target to fill the RELEASE variable.
-POSTGRESQL_TAG ?= sha256:9aa2e8b294818b834ecf5bb83ce84bb5741038aef81650d0a6c0ddea0a0df897
+POSTGRESQL_TAG ?= sha256:5d35b38ae12baf2f1dfd99bbe6d235a7d226a1d9fdaed2c47755b97117ae007a
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 9.6
-RELEASE ?= 9.6.10-$(BUILD_ID)
+RELEASE ?= 9.6.15-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))

--- a/k8s/rabbitmq/Makefile
+++ b/k8s/rabbitmq/Makefile
@@ -7,7 +7,7 @@ APP_ID ?= rabbitmq-managed-updates
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/rabbitmq/VERSION` target to fill the RELEASE variable.
-RABBITMQ_TAG ?= sha256:b93db2c98986ec1d985218ffc512292aa0f9c0059016b727817d4ec10c692c49
+RABBITMQ_TAG ?= sha256:3f6b4c00696132d63f1d4845354c7499fb669713afd4fb9561af109f2ad561b6
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)

--- a/k8s/sonarqube/Makefile
+++ b/k8s/sonarqube/Makefile
@@ -8,7 +8,7 @@ VERIFY_WAIT_TIMEOUT = 600
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/sonarqube/VERSION` target to fill the RELEASE variable.
-SONAR_TAG ?= sha256:f737cf1955425a5864d93c3b482e7bfb7834ac90171b97a776f34e2b0041f5ce
+SONAR_TAG ?= sha256:4a6886e3db2f93764a7a641f214ae52b2ca9ac5563c772f6f67206584abb0d53
 POSTGRESQL_TAG ?= 9.6-kubernetes
 METRICS_EXPORTER_TAG ?= v0.5.1
 

--- a/k8s/sonarqube/Makefile
+++ b/k8s/sonarqube/Makefile
@@ -8,7 +8,7 @@ VERIFY_WAIT_TIMEOUT = 600
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/sonarqube/VERSION` target to fill the RELEASE variable.
-SONAR_TAG ?= sha256:4a6886e3db2f93764a7a641f214ae52b2ca9ac5563c772f6f67206584abb0d53
+SONAR_TAG ?= sha256:f737cf1955425a5864d93c3b482e7bfb7834ac90171b97a776f34e2b0041f5ce
 POSTGRESQL_TAG ?= 9.6-kubernetes
 METRICS_EXPORTER_TAG ?= v0.5.1
 

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -8,13 +8,13 @@ VERIFY_WAIT_TIMEOUT = 1800
 # The digest should be updated automatically, or tag <major>.<minor>.<path/build>
 # should be available on GCP Marketplace.
 # Use `.build/wordpress/VERSION` target to fill the RELEASE variable.
-WP_TAG ?= sha256:b90654a76e1c42594d9230479de8b436c637ee12937a343661d53c12ad4e7c2c
+WP_TAG ?= sha256:477f43a01e1edf44c3f578976855ce5ad24da78fac401dd387f0e7461c187e74
 MYSQL_TAG ?= latest
 METRICS_EXPORTER_TAG ?= v0.5.1
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 TRACK ?= 5.2
-RELEASE ?= 5.2.1-$(BUILD_ID)
+RELEASE ?= 5.2.2-$(BUILD_ID)
 
 $(info ---- TRACK = $(TRACK))
 $(info ---- RELEASE = $(RELEASE))


### PR DESCRIPTION
<!--- /gcbrun -->

```
---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 5.3
---- RELEASE = 5.3.4-20190913-181758
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/grafana-managed-updates/5.3
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/grafana-managed-updates/deployer:5.3.4-20190913-181758
docker run --rm --entrypoint=cat marketplace.gcr.io/google/grafana5@sha256:987e44b3425d4e80061b7a33ace1bc3a9575f033e017e5b3f48144b39d228811 /usr/share/grafana/VERSION
5.3.4

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 3.11
---- RELEASE = 3.11.4-20190913-181839
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/cassandra-managed-updates/3.11
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/cassandra-managed-updates/deployer:3.11.4-20190913-181839
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/cassandra3@sha256:38f4a15b2c6ee559c30d167becbfb2ba8e6ccd476c36a2154a88e12824a7fcf0 CASSANDRA_VERSION
3.11.4

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 6.3
---- RELEASE = 6.3.2-20190913-181853
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/elastic-gke-logging-managed-updates/6.3
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/elastic-gke-logging-managed-updates/deployer:6.3.2-20190913-181853
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/elasticsearch6@sha256:077358140de4b64030d37fbd02d5217b5953dff5bc08bf2352dd5ae90b536978 ELASTICSEARCH_VERSION
6.3.2

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 6.3
---- RELEASE = 6.3.2-20190913-181856
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/elasticsearch-managed-updates/6.3
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/elasticsearch-managed-updates/deployer:6.3.2-20190913-181856
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/elasticsearch6@sha256:077358140de4b64030d37fbd02d5217b5953dff5bc08bf2352dd5ae90b536978 ELASTICSEARCH_VERSION
6.3.2

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 5.3
---- RELEASE = 5.3.4-20190913-181858
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/grafana-managed-updates/5.3
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/grafana-managed-updates/deployer:5.3.4-20190913-181858
docker run --rm --entrypoint=cat marketplace.gcr.io/google/grafana5@sha256:987e44b3425d4e80061b7a33ace1bc3a9575f033e017e5b3f48144b39d228811 /usr/share/grafana/VERSION
5.3.4

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 1.7
---- RELEASE = 1.7.7-20190913-181900
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/influxdb-managed-updates/1.7
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/influxdb-managed-updates/deployer:1.7.7-20190913-181900
docker run --rm marketplace.gcr.io/google/influxdb1@sha256:ddacedb0bc277d2359eef41a7f0ae3f29918876974815a5197ddd44377ffb12a influxd version
InfluxDB v1.7.7 (git: 1.7 f8fdf652f348fc9980997fe1c972e2b79ddd13b0)

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 2.176
---- RELEASE = 2.176.3-20190913-181904
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/jenkins-managed-updates/2.176
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/jenkins-managed-updates/deployer:2.176.3-20190913-181904
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/jenkins2@sha256:87f38f32fd9bed856934144bed9bfd16d4a624c5a1504e808bf1532de564c571 JENKINS_VERSION
2.176.3

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 10.3
---- RELEASE = 10.3.17-20190913-182338
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/mariadb-managed-updates/10.3
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/mariadb-managed-updates/deployer:10.3.17-20190913-182338
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/mariadb10@sha256:0e3b4b07db1b583cea157671b43c83f3c84204c40ae0c91cdda2ad520f326f15 MARIADB_VERSION \
  | awk -F'+' '{ print $1 }' \
  | awk -F':' '{ print $2 }'
10.3.17

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 1.5
---- RELEASE = 1.5.16-20190913-181916
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/memcached-managed-updates/1.5
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/memcached-managed-updates/deployer:1.5.16-20190913-181916
docker run --rm marketplace.gcr.io/google/memcached1@sha256:a81eb58ec89cef45e167060f4621b0694f2658ee0944c96f67ba950cab5cda1e -V | awk '{ print $2 }'
1.5.16

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 1.15
---- RELEASE = 1.15.12-20190913-181924
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/nginx-managed-updates/1.15
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/nginx-managed-updates/deployer:1.15.12-20190913-181924
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/nginx1@sha256:c797f96cf1529764cf8674a757d4f85e20f410912380ed446f3f032f5edb29a3 NGINX_VERSION | awk -F* '{ print $1 }'
1.15.12

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 9.6
---- RELEASE = 9.6.15-20190913-181932
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/postgresql-managed-updates/9.6
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/postgresql-managed-updates/deployer:9.6.15-20190913-181932
docker run --rm marketplace.gcr.io/google/postgresql9@sha256:5d35b38ae12baf2f1dfd99bbe6d235a7d226a1d9fdaed2c47755b97117ae007a postgres -V 2>/dev/null | tail -n 1 | awk '{print $NF}'
9.6.15

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 3.7
---- RELEASE = 3.7.13-20190913-181946
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/rabbitmq-managed-updates/3.7
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/rabbitmq-managed-updates/deployer:3.7.13-20190913-181946
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/rabbitmq3@sha256:3f6b4c00696132d63f1d4845354c7499fb669713afd4fb9561af109f2ad561b6 RABBITMQ_VERSION
3.7.13

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 7.7
---- RELEASE = 7.7.0-20190913-181957
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/sonarqube-managed-updates/7.7
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/sonarqube-managed-updates/deployer:7.7.0-20190913-181957
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/sonarqube7@sha256:f737cf1955425a5864d93c3b482e7bfb7834ac90171b97a776f34e2b0041f5ce SONAR_VERSION
7.7

---- REGISTRY = gcr.io/XXX
---- GCS_URL = gs://XXX
---- NAMESPACE = default
---- TRACK = 5.2
---- RELEASE = 5.2.2-20190913-182029
---- MARKETPLACE_TOOLS_TAG = 0.8.0-alpha06
---- APP_GCS_PATH = gs://XXX/wordpress-managed-updates/5.2
---- APP_DEPLOYER_IMAGE = gcr.io/XXX/wordpress-managed-updates/deployer:5.2.2-20190913-182029
docker run --rm --entrypoint=printenv marketplace.gcr.io/google/wordpress5-php7-apache@sha256:477f43a01e1edf44c3f578976855ce5ad24da78fac401dd387f0e7461c187e74 WORDPRESS_VERSION
5.2.2
```