### PR TITLE
Remove needs-triage label.

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,3 @@
-needs-triage:
-- '**'
 kind/docker:
 - 'docker/**'
 - 'cloudbuild-docker.yaml'


### PR DESCRIPTION
`needs-triage` is labeled every time a commit is pushed, so it doesn't have sense to add this label everytime.

<!--- /gcbrun -->
