### PR TITLE
Bump Elasticsearch to 7.3.2

### DIFF
--- a/vm/chef/cookbooks/elasticsearch/attributes/default.rb
+++ b/vm/chef/cookbooks/elasticsearch/attributes/default.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2019 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,6 +21,3 @@ default['elasticsearch']['repository_url'] =
   "https://artifacts.elastic.co/packages/#{default['elasticsearch']['release']}.x/apt"
 default['elasticsearch']['keyserver_url'] =
   'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
-
-default['elasticsearch']['x-pack']['download_url'] =
-  "https://artifacts.elastic.co/downloads/packs/x-pack/x-pack-#{default['elasticsearch']['version']}.zip"

--- a/vm/chef/cookbooks/elasticsearch/attributes/default.rb
+++ b/vm/chef/cookbooks/elasticsearch/attributes/default.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['elasticsearch']['version'] = '5.6.8'
+default['elasticsearch']['version'] = '7.3.2'
 
 default['elasticsearch']['release'] =
   default['elasticsearch']['version'].split('.')[0]

--- a/vm/chef/cookbooks/elasticsearch/files/elasticsearch
+++ b/vm/chef/cookbooks/elasticsearch/files/elasticsearch
@@ -22,7 +22,7 @@
 #   * Bootstrap the node
 #
 
-source /opt/c2d/elasticsearch-utils || exit
+source /opt/c2d/elasticsearch-utils || exit 1
 
 readonly es_cluster_name="$(get_attribute_value "es_cluster_name")"
 readonly es_nodes="$(get_attribute_value "es_nodes")"

--- a/vm/chef/cookbooks/elasticsearch/files/elasticsearch
+++ b/vm/chef/cookbooks/elasticsearch/files/elasticsearch
@@ -22,22 +22,17 @@
 #   * Bootstrap the node
 #
 
-source /opt/c2d/elasticsearch-utils || exit 1
-
-readonly es_xpack_zip_uri="file:///opt/c2d/downloads/xpack.zip"
+source /opt/c2d/elasticsearch-utils || exit
 
 readonly es_cluster_name="$(get_attribute_value "es_cluster_name")"
 readonly es_nodes="$(get_attribute_value "es_nodes")"
-readonly es_install_xpack="$(get_attribute_value "es_install_xpack" \
-  | tr '[:upper:]' '[:lower:]')"
 
 readonly es_password="$(get_attribute_value "es_password")"
 readonly kibana_password="$(get_attribute_value "kibana_password")"
 readonly logstash_sys_password="$(get_attribute_value "logstash_sys_password")"
 
-# If X-Pack is installed, it sets a basic security for http connections
+# Sets a basic security for http connections
 # and configures default username (elastic) and password (changeme).
-# If the installation does not include X-Pack, there is no password set.
 readonly es_default_password="changeme"
 
 readonly es_current_node="$(hostname)"
@@ -90,12 +85,6 @@ fill_in_config_template \
 echo "Starting elasticsearch in single-node mode"
 service elasticsearch start
 
-# Install X-Pack in single-node mode
-if [[ "${es_install_xpack:-}" == "true" ]]; then
-  echo "Installing X-Pack"
-  /usr/share/elasticsearch/bin/elasticsearch-plugin install -b "${es_xpack_zip_uri}"
-fi
-
 # Prepare a list of "gossiping" nodes in cluster for unicast.
 es_unicast_hosts="\"${es_first_hostname}\""
 if [[ "${es_nodes_count}" -ge 3 ]]; then
@@ -116,30 +105,25 @@ service elasticsearch restart
 
 systemctl enable elasticsearch
 
-if [[ "${es_install_xpack:-}" == "true" ]]; then
-  # X-Pack creates a simple security mechanism with default user and password.
-  # It is changed to generated one, but calling the operation only once
-  # for the whole cluster - it is propagated to all nodes.
-  if [[ "${es_current_node}" == "${es_first_hostname}" ]]; then
-    echo "First node - waiting for green before changing password"
-    wait_for_green_elastic_cluster "${es_nodes_count}" "${es_default_password}"
+# X-Pack creates a simple security mechanism with default user and password.
+# It is changed to generated one, but calling the operation only once
+# for the whole cluster - it is propagated to all nodes.
+if [[ "${es_current_node}" == "${es_first_hostname}" ]]; then
+  echo "First node - waiting for green before changing password"
+  wait_for_green_elastic_cluster "${es_nodes_count}" "${es_default_password}"
+  # Change elastic user password.
+  change_user_password \
+    elastic "${es_default_password}" \
+    elastic "${es_password}"
 
-    # Change elastic user password.
-    change_user_password \
-      elastic "${es_default_password}" \
-      elastic "${es_password}"
+  # Change kibana user password.
+  change_user_password \
+    elastic "${es_password}" \
+    kibana "${kibana_password}"
 
-    # Change kibana user password.
-    change_user_password \
-      elastic "${es_password}" \
-      kibana "${kibana_password}"
-
-    # Change logstash_system user password.
-    change_user_password \
-      elastic "${es_password}" \
-      logstash_system "${logstash_sys_password}"
-  fi
-  wait_for_green_elastic_cluster "${es_nodes_count}" "${es_password}"
-else
-  wait_for_green_elastic_cluster "${es_nodes_count}"
+  # Change logstash_system user password.
+  change_user_password \
+    elastic "${es_password}" \
+    logstash_system "${logstash_sys_password}"
 fi
+wait_for_green_elastic_cluster "${es_nodes_count}" "${es_password}"

--- a/vm/chef/cookbooks/elasticsearch/recipes/default.rb
+++ b/vm/chef/cookbooks/elasticsearch/recipes/default.rb
@@ -66,15 +66,6 @@ cookbook_file '/opt/c2d/elasticsearch-utils' do
   action :create
 end
 
-# Dowload X-Pack for Elasticsearch
-remote_file '/opt/c2d/downloads/xpack.zip' do
-  source node['elasticsearch']['x-pack']['download_url']
-  mode '0644'
-  action :create
-  retries 5
-  retry_delay 30
-end
-
 # Download elasticsearch source files
 remote_file '/usr/src/elasticsearch_src.tar.gz' do
   source "https://github.com/elastic/elasticsearch/archive/v#{node['elasticsearch']['version']}.tar.gz"


### PR DESCRIPTION
<!--- /gcbrun -->
Elasticsearch has xpacks included as of version 6.3 and the cookbooks needed to be changed to remove the download/install of xpacks.
