### PR TITLE
Update kube-state-metrics-deployment.yaml

### DIFF
--- a/k8s/prometheus/manifest/kube-state-metrics-deployment.yaml
+++ b/k8s/prometheus/manifest/kube-state-metrics-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 150Mi
           requests:
             cpu: 100m
             memory: 30Mi


### PR DESCRIPTION
This click to deploy has been failing for months. Needs a dramatic increase in memory limit for app controller manager.

Fix for: https://github.com/GoogleCloudPlatform/click-to-deploy/issues/592

<!--- /gcbrun -->
