### PR TITLE
Revert "Bumped ceph to nautilus"

### DIFF
--- a/vm/chef/cookbooks/ceph/attributes/default.rb
+++ b/vm/chef/cookbooks/ceph/attributes/default.rb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['ceph']['version'] = 'nautilus'
+default['ceph']['version'] = 'luminous'
 default['ceph']['deploymentuser'] = 'cephdep'
 
 default['ceph']['adminnodepackages'] = %w(ceph-deploy rsync)


### PR DESCRIPTION
Reverts GoogleCloudPlatform/click-to-deploy#767

The update breaks the startup scripts. Investigation will be need to fix the scripts to work for the newer version.