### PR TITLE
Prometheus: Automatically scrape Grafana metrics

### DIFF
--- a/k8s/prometheus/manifest/grafana-statefulset.yaml
+++ b/k8s/prometheus/manifest/grafana-statefulset.yaml
@@ -13,6 +13,8 @@ spec:
     matchLabels: *Labels
   template:
     metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
       labels: *Labels
     spec:
       serviceAccountName: $GRAFANA_SERVICE_ACCOUNT


### PR DESCRIPTION
The built-in Prometheus plugin/datasource for Grafana ships with dashboards that rely on these metrics – and even if you don't want to use those, I figure it's still nice to have the metrics.

<!--- /gcbrun -->
