### PR TITLE
Add names to k8s triggers

### DIFF
--- a/triggers/k8s/airflow-operator.yaml
+++ b/triggers/k8s/airflow-operator.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: e84b1610-5061-49af-b8e0-62665d2369c5
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/airflow-operator/**
 - k8s/*
-name: e84b1610-5061-49af-b8e0-62665d2369c5
+name: Trigger-for-K8s-airflow-operator
 substitutions:
   _SOLUTION_NAME: airflow-operator

--- a/triggers/k8s/cassandra.yaml
+++ b/triggers/k8s/cassandra.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 2309e7e9-b39c-4b64-a618-9faadb816b9d
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/cassandra/**
 - k8s/*
-name: 2309e7e9-b39c-4b64-a618-9faadb816b9d
+name: Trigger-for-K8s-cassandra
 substitutions:
   _SOLUTION_NAME: cassandra

--- a/triggers/k8s/consul.yaml
+++ b/triggers/k8s/consul.yaml
@@ -20,7 +20,6 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 5b0db490-4cc3-411c-a550-26b7c55457cf
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile

--- a/triggers/k8s/elastic-gke-logging.yaml
+++ b/triggers/k8s/elastic-gke-logging.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 9e3fcca4-095f-49fc-b0ed-9eab6cc6063f
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/elastic-gke-logging/**
 - k8s/*
-name: 9e3fcca4-095f-49fc-b0ed-9eab6cc6063f
+name: Trigger-for-K8s-elastic-gke-logging
 substitutions:
   _SOLUTION_NAME: elastic-gke-logging

--- a/triggers/k8s/elasticsearch.yaml
+++ b/triggers/k8s/elasticsearch.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 91534c89-fc24-4a32-a260-c0ff95359476
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/elasticsearch/**
 - k8s/*
-name: 91534c89-fc24-4a32-a260-c0ff95359476
+name: Trigger-for-K8s-elasticsearch
 substitutions:
   _SOLUTION_NAME: elasticsearch

--- a/triggers/k8s/etcd.yaml
+++ b/triggers/k8s/etcd.yaml
@@ -20,7 +20,6 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 12b8398d-9d41-4709-bc14-f4180083854d
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile

--- a/triggers/k8s/gatekeeper.yaml
+++ b/triggers/k8s/gatekeeper.yaml
@@ -21,9 +21,10 @@ github:
     branch: .*
     commentControl: COMMENTS_ENABLED
 includedFiles:
-  - cloudbuild-k8s.yaml
-  - k8s.Dockerfile
-  - k8s/gatekeeper/**
-  - k8s/*
+- cloudbuild-k8s.yaml
+- k8s.Dockerfile
+- k8s/gatekeeper/**
+- k8s/*
+name: Trigger-for-K8s-flink-operator
 substitutions:
   _SOLUTION_NAME: gatekeeper

--- a/triggers/k8s/grafana.yaml
+++ b/triggers/k8s/grafana.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: ded04bd3-7425-409f-8d89-458fd305b79d
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/grafana/**
 - k8s/*
-name: ded04bd3-7425-409f-8d89-458fd305b79d
+name: Trigger-for-K8s-grafana
 substitutions:
   _SOLUTION_NAME: grafana

--- a/triggers/k8s/influxdb.yaml
+++ b/triggers/k8s/influxdb.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 3e31dc4e-6760-4af1-94d9-c013903c8a16
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/influxdb/**
 - k8s/*
-name: 3e31dc4e-6760-4af1-94d9-c013903c8a16
+name: Trigger-for-K8s-influxdb
 substitutions:
   _SOLUTION_NAME: influxdb

--- a/triggers/k8s/jenkins.yaml
+++ b/triggers/k8s/jenkins.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 1b48cc75-132c-4c63-9788-b09099ff9cbe
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/jenkins/**
 - k8s/*
-name: 1b48cc75-132c-4c63-9788-b09099ff9cbe
+name: Trigger-for-K8s-jenkins
 substitutions:
   _SOLUTION_NAME: jenkins

--- a/triggers/k8s/mariadb-galera.yaml
+++ b/triggers/k8s/mariadb-galera.yaml
@@ -20,7 +20,6 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 99f8f5f5-6002-48a6-9429-5956b8386633
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile

--- a/triggers/k8s/mariadb.yaml
+++ b/triggers/k8s/mariadb.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: c22e64f8-2375-4144-926d-2de5924c61da
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/mariadb/**
 - k8s/*
-name: c22e64f8-2375-4144-926d-2de5924c61da
+name: Trigger-for-K8s-mariadb
 substitutions:
   _SOLUTION_NAME: mariadb

--- a/triggers/k8s/memcached.yaml
+++ b/triggers/k8s/memcached.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 0435e2cb-4983-4823-af0a-e397e0a66e4e
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/memcached/**
 - k8s/*
-name: 0435e2cb-4983-4823-af0a-e397e0a66e4e
+name: Trigger-for-K8s-memcached
 substitutions:
   _SOLUTION_NAME: memcached

--- a/triggers/k8s/nginx.yaml
+++ b/triggers/k8s/nginx.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 9283c1ef-4642-459b-b09a-d4b62f7611bc
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/nginx/**
 - k8s/*
-name: 9283c1ef-4642-459b-b09a-d4b62f7611bc
+name: Trigger-for-K8s-nginx
 substitutions:
   _SOLUTION_NAME: nginx

--- a/triggers/k8s/postgresql.yaml
+++ b/triggers/k8s/postgresql.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 5ec0bae9-b96e-4c42-a1cc-a7c6a57dea50
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/postgresql/**
 - k8s/*
-name: 5ec0bae9-b96e-4c42-a1cc-a7c6a57dea50
+name: Trigger-for-K8s-postgresql
 substitutions:
   _SOLUTION_NAME: postgresql

--- a/triggers/k8s/prometheus.yaml
+++ b/triggers/k8s/prometheus.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 3ae7123a-8f5a-4d70-ab40-532843a4f4b5
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/prometheus/**
 - k8s/*
-name: 3ae7123a-8f5a-4d70-ab40-532843a4f4b5
+name: Trigger-for-K8s-prometheus
 substitutions:
   _SOLUTION_NAME: prometheus

--- a/triggers/k8s/rabbitmq.yaml
+++ b/triggers/k8s/rabbitmq.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: fd9c8695-2911-4041-8ab8-b3f60fafb47d
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/rabbitmq/**
 - k8s/*
-name: fd9c8695-2911-4041-8ab8-b3f60fafb47d
+name: Trigger-for-K8s-rabbitmq
 substitutions:
   _SOLUTION_NAME: rabbitmq

--- a/triggers/k8s/sample-app.yaml
+++ b/triggers/k8s/sample-app.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 93973567-ac6f-4368-9e46-99273d32f37b
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/sample-app/**
 - k8s/*
-name: 93973567-ac6f-4368-9e46-99273d32f37b
+name: Trigger-for-K8s-sample-app
 substitutions:
   _SOLUTION_NAME: sample-app

--- a/triggers/k8s/sonarqube.yaml
+++ b/triggers/k8s/sonarqube.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 655047ba-a7d2-4b7d-8ca7-971f84e9659a
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/sonarqube/**
 - k8s/*
-name: 655047ba-a7d2-4b7d-8ca7-971f84e9659a
+name: Trigger-for-K8s-sonarqube
 substitutions:
   _SOLUTION_NAME: sonarqube

--- a/triggers/k8s/spark-operator.yaml
+++ b/triggers/k8s/spark-operator.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: 2bbc7130-ee2f-47b4-93aa-aa3fae5bf577
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/spark-operator/**
 - k8s/*
-name: 2bbc7130-ee2f-47b4-93aa-aa3fae5bf577
+name: Trigger-for-K8s-spark-operator
 substitutions:
   _SOLUTION_NAME: spark-operator

--- a/triggers/k8s/wordpress.yaml
+++ b/triggers/k8s/wordpress.yaml
@@ -21,12 +21,11 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: ad2f15de-552e-4b47-b310-e589b932aca1
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile
 - k8s/wordpress/**
 - k8s/*
-name: ad2f15de-552e-4b47-b310-e589b932aca1
+name: Trigger-for-K8s-wordpress
 substitutions:
   _SOLUTION_NAME: wordpress

--- a/triggers/k8s/zookeeper.yaml
+++ b/triggers/k8s/zookeeper.yaml
@@ -20,7 +20,6 @@ github:
   pullRequest:
     branch: .*
     commentControl: COMMENTS_ENABLED
-id: a897ba31-bdfa-4455-8027-ba8429470033
 includedFiles:
 - cloudbuild-k8s.yaml
 - k8s.Dockerfile


### PR DESCRIPTION
<!--- /gcbrun -->
This makes it easier to identify each trigger in the list. Some triggers are already named after the solution, but old triggers used to be named as a guid. The triggers are already replaced in the project `cloud-marketplace-ops-test`