### PR TITLE
Bump the images version for P+G: 2.2->2.11

### DIFF
--- a/k8s/prometheus/Makefile
+++ b/k8s/prometheus/Makefile
@@ -137,8 +137,8 @@ app/build:: .build/prometheus/alertmanager \
 .build/prometheus/grafana: .build/var/REGISTRY \
                            .build/var/TAG \
                            | .build/prometheus
-	docker pull marketplace.gcr.io/google/grafana5:5.3
-	docker tag marketplace.gcr.io/google/grafana5:5.3 "$(REGISTRY)/prometheus/grafana:$(TAG)"
+	docker pull marketplace.gcr.io/google/grafana6:6.5
+	docker tag marketplace.gcr.io/google/grafana6:6.5 "$(REGISTRY)/prometheus/grafana:$(TAG)"
 	docker push "$(REGISTRY)/prometheus/grafana:$(TAG)"
 	@touch "$@"
 

--- a/k8s/prometheus/README.md
+++ b/k8s/prometheus/README.md
@@ -168,7 +168,7 @@ export PROMETHEUS_REPLICAS=2
 Configure the container images:
 
 ```shell
-TAG=2.2
+TAG=2.11
 export IMAGE_PROMETHEUS="marketplace.gcr.io/google/prometheus:${TAG}"
 export IMAGE_ALERTMANAGER="marketplace.gcr.io/google/prometheus/alertmanager:${TAG}"
 export IMAGE_KUBE_STATE_METRICS="marketplace.gcr.io/google/prometheus/kubestatemetrics:${TAG}"


### PR DESCRIPTION
All P+G images with tag 2.2 are gone and the latest ones are with tag 2.11.