### PR TITLE
VM - Solr - Dynamically get the latest version

### DIFF
--- a/vm/chef/cookbooks/solr/attributes/default.rb
+++ b/vm/chef/cookbooks/solr/attributes/default.rb
@@ -12,7 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'net/http'
-
 default['solr']['version'] = '8.8.1'
 default['solr']['packages'] = ['lsof']

--- a/vm/chef/cookbooks/solr/attributes/default.rb
+++ b/vm/chef/cookbooks/solr/attributes/default.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,5 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['solr']['version'] = '8.6.2'
+require 'net/http'
+
+# Find latest version for Solr 8
+uri = URI('https://downloads.apache.org/lucene/solr/')
+response = Net::HTTP.get(uri)
+match = response.match /(?<version>8\.\d+\.\d+)/
+
+default['solr']['version'] = match[:version]
 default['solr']['packages'] = ['lsof']

--- a/vm/chef/cookbooks/solr/attributes/default.rb
+++ b/vm/chef/cookbooks/solr/attributes/default.rb
@@ -14,10 +14,5 @@
 
 require 'net/http'
 
-# Find latest version for Solr 8
-uri = URI('https://downloads.apache.org/lucene/solr/')
-response = Net::HTTP.get(uri)
-match = response.match /(?<version>8\.\d+\.\d+)/
-
-default['solr']['version'] = match[:version]
+default['solr']['version'] = '8.8.1'
 default['solr']['packages'] = ['lsof']

--- a/vm/chef/cookbooks/solr/recipes/default.rb
+++ b/vm/chef/cookbooks/solr/recipes/default.rb
@@ -26,13 +26,13 @@ end
 
 # Download sha512 checksum from apache
 remote_file '/tmp/solr-checksum.sha512' do
-  source "https://www-us.apache.org/dist/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz.sha512"
+  source "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz.sha512"
   action :create
 end
 
 # Download solr from apache
 remote_file "/tmp/solr-#{node['solr']['version']}.tgz" do
-  source "https://www-us.apache.org/dist/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz"
+  source "https://archive.apache.org/dist/lucene/solr/#{node['solr']['version']}/solr-#{node['solr']['version']}.tgz"
   verify 'sed -i -e "s/ .*//; s=$=  %{path}=" /tmp/solr-checksum.sha512 && sha512sum -c /tmp/solr-checksum.sha512'
   action :create
 end


### PR DESCRIPTION
Solr keeps only the latest version on this repo, so this change is required so app don't fail after every Solr release. 

This will avoid release failures, keep solr up to date and avoid PRs like these: 
- https://github.com/GoogleCloudPlatform/click-to-deploy/pull/1035/files
- https://github.com/GoogleCloudPlatform/click-to-deploy/pull/1016/files
- https://github.com/GoogleCloudPlatform/click-to-deploy/pull/687/files