### PR TITLE
Made storage class variable name consistent

### DIFF
--- a/k8s/neo4j-ce/README.md
+++ b/k8s/neo4j-ce/README.md
@@ -183,7 +183,7 @@ helm template chart/neo4j-ce \
   --namespace "${NAMESPACE}" \
   --set "neo4j.image.repo=${IMAGE_NEO4J_CE}" \
   --set "neo4j.image.tag=${TAG}" \
-  --set "neo4j.persistence.storageClass=${STORAGE_CLASS}" \
+  --set "neo4j.persistence.storageClass=${NEO4J_STORAGE_CLASS}" \
   --set "neo4j.persistence.size=${PERSISTENT_DISK_SIZE}" \
   --set "neo4j.password=${NEO4J_PASSWORD}" \
   > "${APP_INSTANCE_NAME}_manifest.yaml"


### PR DESCRIPTION
Storage class variable was initially referenced as `NEO4J_STORAGE_CLASS` in the export command but was referenced only as `STORAGE_CLASS` in the helm template command.

<!--- /gcbrun -->
