### PR TITLE
update missing helm examples to v3

### DIFF
--- a/k8s/cassandra/README.md
+++ b/k8s/cassandra/README.md
@@ -199,8 +199,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/cassandra \
-  --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/cassandra \
   --namespace "${NAMESPACE}" \
   --set cassandra.image.repo="${IMAGE_CASSANDRA}" \
   --set cassandra.image.tag="${TAG}" \

--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -198,8 +198,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/elasticsearch \
-  --name "$APP_INSTANCE_NAME" \
+helm template "$APP_INSTANCE_NAME" chart/elasticsearch \
   --namespace "$NAMESPACE" \
   --set elasticsearch.initImage="$IMAGE_INIT" \
   --set elasticsearch.image.repo="$IMAGE_ELASTICSEARCH" \

--- a/k8s/gatekeeper/README.md
+++ b/k8s/gatekeeper/README.md
@@ -145,8 +145,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/gatekeeper \
-  --name $APP_INSTANCE_NAME \
+helm template $APP_INSTANCE_NAME chart/gatekeeper \
   --namespace $NAMESPACE \
   --set gatekeeper.imageGatekeeperRepo=gcr.io/gatekeeper-marketplace/gatekeeper \
   --set gatekeeper.imageGatekeeperTag=$TAG \

--- a/k8s/influxdb/README.md
+++ b/k8s/influxdb/README.md
@@ -220,8 +220,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/influxdb \
-  --name $APP_INSTANCE_NAME \
+helm template $APP_INSTANCE_NAME chart/influxdb \
   --namespace $NAMESPACE \
   --set influxdb.image.repo=$IMAGE_INFLUXDB \
   --set influxdb.image.tag=$TAG \

--- a/k8s/magento/README.md
+++ b/k8s/magento/README.md
@@ -278,8 +278,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/magento \
-    --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/magento \
     --namespace "${NAMESPACE}" \
     --set persistence.storageClass="${DEFAULT_STORAGE_CLASS}" \
     --set magento.image.repo="${IMAGE_MAGENTO}" \

--- a/k8s/mariadb-galera/README.md
+++ b/k8s/mariadb-galera/README.md
@@ -245,8 +245,7 @@ Use `helm template` to expand the template. We recommend that you save
 the expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/mariadb-galera \
-  --name "$APP_INSTANCE_NAME" \
+helm template "$APP_INSTANCE_NAME" chart/mariadb-galera \
   --namespace "$NAMESPACE" \
   --set mariadb.image.repo="$IMAGE_MARIADB" \
   --set mariadb.image.tag="$TAG" \

--- a/k8s/mediawiki/README.md
+++ b/k8s/mediawiki/README.md
@@ -267,8 +267,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/mediawiki \
-    --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/mediawiki \
     --namespace "${NAMESPACE}" \
     --set mediawiki.image.repo="${IMAGE_MEDIAWIKI}" \
     --set mediawiki.image.tag="${TAG}" \

--- a/k8s/nuclio/README.md
+++ b/k8s/nuclio/README.md
@@ -276,8 +276,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the app.
 
 ```shell
-helm template chart/nuclio \
-  --name ${APP_INSTANCE_NAME} \
+helm template ${APP_INSTANCE_NAME} chart/nuclio \
   --namespace ${NAMESPACE} \
   --set controller.image.repo=${IMAGE_CONTROLLER} \
   --set controller.image.tag=${TAG} \


### PR DESCRIPTION
<!--- /gcbrun -->
Missing files from update Helm in #1225 #929
 - magento
 - cassandra
 - elasticsearch
 - gatekeeper
 - influxdb
 - mariadb
 - mediawiki
 - nuclio
