### PR TITLE
VM - WordPress - Use default WP theme instead of a fixed one.

### DIFF
--- a/vm/chef/cookbooks/wordpress/files/wordpress-setup
+++ b/vm/chef/cookbooks/wordpress/files/wordpress-setup
@@ -16,8 +16,13 @@
 
 source /opt/c2d/c2d-utils || exit 1
 
+readonly wordpress_admin_username="admin"
+readonly wordpress_admin_password="$(get_attribute_value "wordpress-admin-password")"
+readonly wordpress_admin_email="$(get_attribute_value "wordpress-admin-email")"
 readonly wordpress_mysql_password="$(get_attribute_value "wordpress-mysql-password")"
 readonly mysql_root_password="$(get_attribute_value "mysql-root-password")"
+
+set +x
 
 mysql -u root -p"${mysql_root_password}" -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY '${wordpress_mysql_password}'"
 echo "Created wordpress user."
@@ -36,9 +41,9 @@ sudo -u www-data wp config create \
 # Run the CLI installer for WordPress
 declare -a args
 args=(--title="WordPress on Google Compute Engine" \
---admin_user=admin \
---admin_password="$(get_attribute_value "wordpress-admin-password")" \
---admin_email="$(get_attribute_value "wordpress-admin-email")" \
+--admin_user="${wordpress_admin_username}" \
+--admin_password="${wordpress_admin_password}" \
+--admin_email="${wordpress_admin_email}" \
 --path=/var/www/html/ \
 --skip-email)
 
@@ -49,4 +54,3 @@ else
 fi
 
 sudo -u www-data wp core install "${args[@]}"
-sudo -u www-data wp theme activate twentyseventeen --path=/var/www/html

--- a/vm/chef/cookbooks/wordpress/files/wordpress-setup
+++ b/vm/chef/cookbooks/wordpress/files/wordpress-setup
@@ -22,8 +22,6 @@ readonly wordpress_admin_email="$(get_attribute_value "wordpress-admin-email")"
 readonly wordpress_mysql_password="$(get_attribute_value "wordpress-mysql-password")"
 readonly mysql_root_password="$(get_attribute_value "mysql-root-password")"
 
-set +x
-
 mysql -u root -p"${mysql_root_password}" -e "CREATE USER 'wordpress'@'localhost' IDENTIFIED BY '${wordpress_mysql_password}'"
 echo "Created wordpress user."
 mysql -u root -p"${mysql_root_password}" -e "GRANT ALL PRIVILEGES ON wordpress.* TO 'wordpress'@'localhost' IDENTIFIED BY '${wordpress_mysql_password}'"


### PR DESCRIPTION
* Theme in master is not packaged by default in WP `twentyseventeen`, which now it's `twentytwentyone` .
* Removing fixed theme, and leaving the default one packaged by WP.
* Minor refactoring
