### PR TITLE
Add OAuth scopes to Jenkins GKE cluster nodes

### DIFF
--- a/k8s/jenkins/README.md
+++ b/k8s/jenkins/README.md
@@ -72,7 +72,9 @@ export ZONE=us-west1-a
 ```
 
 ```shell
-gcloud container clusters create "$CLUSTER" --zone "$ZONE"
+gcloud container clusters create "$CLUSTER" \
+    --scopes cloud-platform,storage-ro \
+    --zone "$ZONE"
 ```
 
 #### Configure `kubectl` to connect to the cluster

--- a/k8s/jenkins/schema.yaml
+++ b/k8s/jenkins/schema.yaml
@@ -12,6 +12,18 @@ x-google-marketplace:
     recommended: false
 
   clusterConstraints:
+    assistedClusterCreation:
+      type: STRICT
+      creationGuidance: Enable the cloud-platform scope to push artifacts to Artifact Registry and Container Registry.
+      gke:
+        nodePool:
+        - numNodes: 3
+          machineType: e2-medium
+    gcp:
+      nodes:
+        requiredOauthScopes:
+        - https://www.googleapis.com/auth/cloud-platform
+        - https://www.googleapis.com/auth/devstorage.read_only
     resources:
     - requests:
         cpu: 100m


### PR DESCRIPTION
The `cloud-platform` scope enables Jenkins agents to publish artifacts
(e.g., container images) to Artifact Registry and Container Registry.

<!--- /gcbrun -->
