### PR TITLE
Use same bazel version as runtime-commons

### DIFF
--- a/docker.Dockerfile
+++ b/docker.Dockerfile
@@ -14,7 +14,7 @@
 
 FROM marketplace.gcr.io/google/debian9 AS build
 
-ENV BAZEL_VERSION 0.13.0
+ENV BAZEL_VERSION 0.19.2
 ENV BAZEL_ARCH linux_amd64_stripped
 
 RUN set -eux \


### PR DESCRIPTION
/gcbrun
