### PR TITLE
VM - Fix chefdk and foodcritic deprecation

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       with:
         python-version: '3.x'
     - name: Install dependencies
-      run: | 
+      run: |
         python -m pip install --upgrade pip jinja2 pyyaml
         wget https://packages.chef.io/files/stable/chefdk/4.2.0/ubuntu/16.04/chefdk_4.2.0-1_amd64.deb
         sudo dpkg -i chefdk_4.2.0-1_amd64.deb

--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,13 @@ python-test: ## Runs tests for Python scripts
 
 .PHONY: vm-lint
 vm-lint: ## Runs lint for Chef cookbooks
-	@docker pull chef/chefdk
+	@docker pull chef/chefworkstation
 	# cookstyle print version
-	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/chef:/chef:ro chef/chefdk --version
+	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/chef:/chef:ro chef/chefworkstation --version
 	# cookstyle on cookbooks
-	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/chef:/chef:ro chef/chefdk /chef/cookbooks
+	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/chef:/chef:ro chef/chefworkstation /chef/cookbooks
 	# cookstyle on tests
-	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/tests:/tests:ro chef/chefdk /tests/solutions
-	# foodcritic print version
-	@docker run --rm --entrypoint foodcritic -v $(PWD)/vm/chef:/chef:ro chef/chefdk --version
-	# foodcritic on cookbooks
-	@docker run --rm --entrypoint foodcritic -v $(PWD)/vm/chef:/chef:ro chef/chefdk --cookbook-path=/chef/cookbooks --rule-file=/chef/.foodcritic --epic-fail=any
+	@docker run --rm --entrypoint cookstyle -v $(PWD)/vm/tests:/tests:ro chef/chefworkstation /tests/solutions
 
 .PHONY: vm-generate-triggers
 vm-generate-triggers: ## Generates and displays GCB triggers for VM

--- a/vm/chef/.rubocop.yml
+++ b/vm/chef/.rubocop.yml
@@ -1,21 +1,21 @@
-ChefStyle/CommentFormat:
+Chef/Style/CommentFormat:
   Enabled: false
 
-ChefCorrectness/TmpPath:
+Chef/Correctness/TmpPath:
   Enabled: false
 
-ChefStyle/FileMode:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
-  Enabled: false
-
-# TODO(wgrzelak): Fix code and remove the rule.
-ChefRedundantCode/NamePropertyIsRequired:
+Chef/Style/FileMode:
   Enabled: false
 
 Style/WordArray:
   Enabled: false
 
-Style/HashSyntax:
+Chef/Modernize/CronDFileOrTemplate:
+  Enabled: false
+
+# TODO(armadom): Fix code and remove the rule.
+Chef/RedundantCode/NamePropertyIsRequired:
+ Enabled: false
+
+Chef/Correctness/MetadataMissingVersion:
   Enabled: false

--- a/vm/chef/cookbooks/apache2/resources/allow_override.rb
+++ b/vm/chef/cookbooks/apache2/resources/allow_override.rb
@@ -1,4 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 property :directory, String, default: ''
+unified_mode true
 
 action :apply do
   bash 'Create template' do

--- a/vm/chef/cookbooks/c2d-config/resources/c2d_startup_script.rb
+++ b/vm/chef/cookbooks/c2d-config/resources/c2d_startup_script.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ property :source, String, name_property: true, required: true
 provides :c2d_startup_script
 
 default_action :cookbook_file
+
+unified_mode true
 
 c2d_startup_count = 0
 c2d_startup_dir = '/opt/c2d/scripts'

--- a/vm/chef/cookbooks/mysql/recipes/install-and-configure-mysqld.rb
+++ b/vm/chef/cookbooks/mysql/recipes/install-and-configure-mysqld.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ end
 
 template '/etc/mysql/mysql.conf.d/mysqld.cnf' do
   source 'mysqld.cnf.erb'
-  variables(
-    :bind_address => node['mysql']['bind_address'],
-    :log_bin_trust_function_creators => node['mysql']['log_bin_trust_function_creators']
-  )
+  variables({
+    bind_address: node['mysql']['bind_address'],
+    log_bin_trust_function_creators: node['mysql']['log_bin_trust_function_creators'],
+  })
 end
 
 c2d_startup_script 'mysql'

--- a/vm/chef/cookbooks/mysql/recipes/install-and-configure-mysqld8.rb
+++ b/vm/chef/cookbooks/mysql/recipes/install-and-configure-mysqld8.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,10 +21,10 @@ end
 
 template '/etc/mysql/mysql.conf.d/mysqld.cnf' do
   source 'mysqld8.cnf.erb'
-  variables(
-    :bind_address => node['mysql']['bind_address'],
-    :log_bin_trust_function_creators => node['mysql']['log_bin_trust_function_creators']
-  )
+  variables({
+    bind_address: node['mysql']['bind_address'],
+    log_bin_trust_function_creators: node['mysql']['log_bin_trust_function_creators'],
+  })
 end
 
 c2d_startup_script 'mysql'

--- a/vm/chef/cookbooks/nginx/recipes/stretch-backports.rb
+++ b/vm/chef/cookbooks/nginx/recipes/stretch-backports.rb
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package 'install packages' do # ~FC009
+package 'install packages' do
   package_name node['nginx']['packages']
   default_release 'stretch-backports'
   action :install

--- a/vm/chef/cookbooks/nodenvm/resources/npm.rb
+++ b/vm/chef/cookbooks/nodenvm/resources/npm.rb
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 property :package, String, default: ''
 property :cwd, String, default: '/'
+unified_mode true
 
 action :install do
   bash 'Install npm package' do

--- a/vm/chef/cookbooks/nodenvm/resources/run.rb
+++ b/vm/chef/cookbooks/nodenvm/resources/run.rb
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 property :command, String, default: ''
 property :cwd, String, default: '/'
+unified_mode true
 
 action :run do
   bash 'Run command in node context' do

--- a/vm/chef/cookbooks/openjdk11/recipes/default.rb
+++ b/vm/chef/cookbooks/openjdk11/recipes/default.rb
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@ apt_update do
   action :update
 end
 
-package 'install packages' do # ~FC009
+package 'install packages' do
   only_if { node['platform_version'].include? '8.' }
   package_name node['openjdk11']['packages']
   default_release 'jessie-backports'

--- a/vm/tests/solutions/.rubocop.yml
+++ b/vm/tests/solutions/.rubocop.yml
@@ -1,4 +1,4 @@
-ChefStyle/CommentFormat:
+Chef/Style/CommentFormat:
   Enabled: false
 
 Style/HashSyntax:


### PR DESCRIPTION
* `chefdk` official container no longer available
  * https://www.chef.io/blog/goodbye-chefdk-hello-chef-workstation
  * https://hub.docker.com/r/chef/chefdk
* `foodcritic` deprecated
  * https://blog.chef.io/goodbye-foodcritic/
  * output: 
  ```
  Foodcritic has been deprecated. Use cookstyle instead, which provides over 200 Chef Infra cops with autocorrection! For more details see https://blog.chef.io/goodbye-foodcritic/
  ```