### PR TITLE
Docker - Keycloak - patch h2database

### DIFF
--- a/docker/keycloak/18/debian11/18.0/Dockerfile
+++ b/docker/keycloak/18/debian11/18.0/Dockerfile
@@ -19,10 +19,12 @@ ENV LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 LC_CTYPE=C.UTF-8 LC_MESSAGES=C.
 COPY --from=build --chown=1000:0 /opt/keycloak /opt/keycloak
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl locales openjdk-11-jre-headless \
+    && apt-get install -y --no-install-recommends curl locales openjdk-11-jre-headless libh2-java \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN cp /usr/share/java/h2-1.4.197.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/18/debian11/18.0/Dockerfile
+++ b/docker/keycloak/18/debian11/18.0/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cp /usr/share/java/h2-*.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
+RUN cp /usr/share/java/h2-1.4.197.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/18/debian11/18.0/Dockerfile
+++ b/docker/keycloak/18/debian11/18.0/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cp /usr/share/java/h2-1.4.197.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
+RUN cp /usr/share/java/h2-*.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/templates/Dockerfile.template
+++ b/docker/keycloak/templates/Dockerfile.template
@@ -21,10 +21,12 @@ ENV LANGUAGE=C.UTF-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 LC_CTYPE=C.UTF-8 LC_MESSAGES=C.
 COPY --from=build --chown=1000:0 /opt/keycloak /opt/keycloak
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl locales openjdk-11-jre-headless \
+    && apt-get install -y --no-install-recommends curl locales openjdk-11-jre-headless libh2-java \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+RUN cp /usr/share/java/h2-1.4.197.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/templates/Dockerfile.template
+++ b/docker/keycloak/templates/Dockerfile.template
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cp /usr/share/java/h2-{{ $h2database.Version }}.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
+RUN cp /usr/share/java/h2-{{ $h2database.Version }}.jar /opt/keycloak/lib/lib/main/com.h2database.h2-{{ $h2database.Version }}.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/templates/Dockerfile.template
+++ b/docker/keycloak/templates/Dockerfile.template
@@ -1,4 +1,5 @@
 {{- $keycloak := index .Packages "keycloak" -}}
+{{- $h2database := index .Packages "h2database" -}}
 
 FROM marketplace.gcr.io/google/debian11:latest AS build
 
@@ -26,7 +27,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cp /usr/share/java/h2-*.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
+RUN cp /usr/share/java/h2-{{ $h2database.Version }}.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/templates/Dockerfile.template
+++ b/docker/keycloak/templates/Dockerfile.template
@@ -26,7 +26,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cp /usr/share/java/h2-1.4.197.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
+RUN cp /usr/share/java/h2-*.jar /opt/keycloak/lib/lib/main/com.h2database.h2-1.4.197.jar
 
 ENV KC_DB=postgres
 RUN /opt/keycloak/bin/kc.sh build --db=postgres

--- a/docker/keycloak/versions.yaml
+++ b/docker/keycloak/versions.yaml
@@ -20,6 +20,8 @@ versions:
   packages:
     keycloak:
       version: 18.0.0
+    h2database:
+      version: 1.4.197
   repo: keycloak18
   tags:
   - '18.0.0-debian11'


### PR DESCRIPTION
Use the patched h2 database from the debian security-stable repo.