### PR TITLE
Docker - Gogs - Fix entrypoint

### DIFF
--- a/docker/gogs/0/debian11/0.12/entrypoint.sh
+++ b/docker/gogs/0/debian11/0.12/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 prepare_gogs_config() {
-    # create app.ini config 
+    # create app.ini config
+    mkdir -p /data/gogs/conf
     cat /app/gogs/app.ini.env | \
     envsubst > /data/gogs/conf/app.ini
 }

--- a/docker/gogs/0/debian11/0.12/run_test.sh
+++ b/docker/gogs/0/debian11/0.12/run_test.sh
@@ -5,7 +5,7 @@ echo "Step 1. Create testuser"
 
 echo "Step 2. Get user info"
 export TEST_USERNAME=$(curl -s -u "testuser:testpassword" localhost:3000/api/v1/users/testuser/|jq -r .username)
-if [ "$TEST_USERNAME" != "testuser" ];then 
+if [ "${TEST_USERNAME}" != "testuser" ];then 
   echo "Something went wrong with API!";
   exit 1
 else
@@ -17,7 +17,7 @@ curl -s -u "testuser:testpassword" -H "Content-Type: application/json"  -d "{\"N
 
 echo "Step 4. Ger repo info"
 export TEST_REPO=$(curl -s -u "testuser:testpassword" localhost:3000/api/v1/repos/testuser/testrepo/|jq -r .clone_url)
-if [ "$TEST_REPO" != "http://localhost:3000/testuser/testrepo.git" ];then 
+if [ "${TEST_REPO}" != "${GOGS_EXTERNAL_URL}testuser/testrepo.git" ];then 
   echo "Something went wrong with API!";
   exit 1
 else
@@ -25,5 +25,5 @@ else
 fi
 
 echo "Step 5. Clone test repo"
-git clone $TEST_REPO /tmp/testrepo/ 2>&1 || true
+git clone ${TEST_REPO} /tmp/testrepo/ 2>&1 || true
 

--- a/docker/gogs/README.md
+++ b/docker/gogs/README.md
@@ -77,7 +77,7 @@ Or you can use `docker run` directly:
 docker run --name gogs -p 3000:3000 -d marketplace.gcr.io/google/gogs0
 ```
 
-### <a name="Runnung-Gogs-with-PostgreSQL"></a>Running Conjur with PostgreSQL
+### <a name="Runnung-Gogs-with-PostgreSQL"></a>Running Gogs with PostgreSQL
 
 Use the following content for the `docker-compose.yml` file, then run `docker-compose up`.
 

--- a/docker/gogs/templates/entrypoint.sh
+++ b/docker/gogs/templates/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 prepare_gogs_config() {
-    # create app.ini config 
+    # create app.ini config
+    mkdir -p /data/gogs/conf
     cat /app/gogs/app.ini.env | \
     envsubst > /data/gogs/conf/app.ini
 }

--- a/docker/gogs/templates/run_test.sh
+++ b/docker/gogs/templates/run_test.sh
@@ -5,7 +5,7 @@ echo "Step 1. Create testuser"
 
 echo "Step 2. Get user info"
 export TEST_USERNAME=$(curl -s -u "testuser:testpassword" localhost:3000/api/v1/users/testuser/|jq -r .username)
-if [ "$TEST_USERNAME" != "testuser" ];then 
+if [ "${TEST_USERNAME}" != "testuser" ];then 
   echo "Something went wrong with API!";
   exit 1
 else
@@ -17,7 +17,7 @@ curl -s -u "testuser:testpassword" -H "Content-Type: application/json"  -d "{\"N
 
 echo "Step 4. Ger repo info"
 export TEST_REPO=$(curl -s -u "testuser:testpassword" localhost:3000/api/v1/repos/testuser/testrepo/|jq -r .clone_url)
-if [ "$TEST_REPO" != "http://localhost:3000/testuser/testrepo.git" ];then 
+if [ "${TEST_REPO}" != "${GOGS_EXTERNAL_URL}testuser/testrepo.git" ];then 
   echo "Something went wrong with API!";
   exit 1
 else
@@ -25,5 +25,5 @@ else
 fi
 
 echo "Step 5. Clone test repo"
-git clone $TEST_REPO /tmp/testrepo/ 2>&1 || true
+git clone ${TEST_REPO} /tmp/testrepo/ 2>&1 || true
 


### PR DESCRIPTION
```
DEPLOYER SMOKE_TEST + testrunner -logtostderr --test_spec=/tests/gogs.yaml
DEPLOYER SMOKE_TEST I1010 10:52:08.626105       7 main.go:86] >>> Running /tests/gogs.yaml
DEPLOYER SMOKE_TEST I1010 10:52:08.627005       7 main.go:136]  >   0: kubectl smoke test
DEPLOYER SMOKE_TEST I1010 10:52:08.689770       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I1010 10:52:08.689905       7 main.go:136]  >   1: Wait for the webserver get ready
DEPLOYER SMOKE_TEST I1010 10:52:08.996756       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I1010 10:52:08.996787       7 main.go:136]  >   2: Try to run test
DEPLOYER SMOKE_TEST I1010 10:52:09.654059       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I1010 10:52:09.654216       7 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I1010 10:52:09.654274       7 main.go:123]  >   0: kubectl smoke test: PASSED
DEPLOYER SMOKE_TEST I1010 10:52:09.654365       7 main.go:123]  >   1: Wait for the webserver get ready: PASSED
DEPLOYER SMOKE_TEST I1010 10:52:09.654383       7 main.go:123]  >   2: Try to run test: PASSED
DEPLOYER SMOKE_TEST I1010 10:52:09.654389       7 main.go:97] >>> SUMMARY: All passed
DEPLOYER SMOKE_TEST 
DEPLOYER SMOKE_TEST Using /opt/kubectl/1.22/kubectl (server=1.22)
```