### PR TITLE
Fix helm template command to work with current Helm Versions

### DIFF
--- a/k8s/amppackager/README.md
+++ b/k8s/amppackager/README.md
@@ -199,8 +199,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/amppackager \
-  --name "$APP_INSTANCE_NAME" \
+helm template "$APP_INSTANCE_NAME" chart/amppackager \
   --namespace "$NAMESPACE" \
   --set replicaCount="$REPLICAS" \
   --set image.repo="$IMAGE_AMPPACKAGER" \

--- a/k8s/cassandra/README.md
+++ b/k8s/cassandra/README.md
@@ -192,8 +192,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/cassandra \
-  --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/cassandra \
   --namespace "${NAMESPACE}" \
   --set cassandra.image.repo="${IMAGE_CASSANDRA}" \
   --set cassandra.image.tag="${TAG}" \

--- a/k8s/dragonfly/README.md
+++ b/k8s/dragonfly/README.md
@@ -206,8 +206,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/dragonfly \
-    --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/dragonfly \
     --namespace "${NAMESPACE}" \
     --set persistence.storageClass="${DEFAULT_STORAGE_CLASS}" \
     --set manager.image.repo="${IMAGE_REGISTRY}" \

--- a/k8s/elasticsearch/README.md
+++ b/k8s/elasticsearch/README.md
@@ -198,8 +198,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/elasticsearch \
-  --name "$APP_INSTANCE_NAME" \
+helm template "$APP_INSTANCE_NAME" chart/elasticsearch \
   --namespace "$NAMESPACE" \
   --set elasticsearch.initImage="$IMAGE_INIT" \
   --set elasticsearch.image.repo="$IMAGE_ELASTICSEARCH" \

--- a/k8s/gatekeeper/README.md
+++ b/k8s/gatekeeper/README.md
@@ -145,8 +145,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/gatekeeper \
-  --name $APP_INSTANCE_NAME \
+helm template "${APP_INSTANCE_NAME}" chart/gatekeeper \
   --namespace $NAMESPACE \
   --set gatekeeper.imageGatekeeperRepo=gcr.io/gatekeeper-marketplace/gatekeeper \
   --set gatekeeper.imageGatekeeperTag=$TAG \

--- a/k8s/gitea/README.md
+++ b/k8s/gitea/README.md
@@ -236,8 +236,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/gitea \
-  --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/gitea \
   --namespace "${NAMESPACE}" \
   --set gitea.image.repo="${IMAGE_GITEA}" \
   --set gitea.image.tag="${TAG}" \

--- a/k8s/gitlab/README.md
+++ b/k8s/gitlab/README.md
@@ -313,8 +313,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/gitlab \
-  --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/gitlab \
   --namespace "${NAMESPACE}" \
   --set gitlab.image.repo="${IMAGE_GITLAB}" \
   --set gitlab.image.tag="${TAG}" \

--- a/k8s/influxdb/README.md
+++ b/k8s/influxdb/README.md
@@ -220,8 +220,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the application.
 
 ```shell
-helm template chart/influxdb \
-  --name $APP_INSTANCE_NAME \
+helm template "${APP_INSTANCE_NAME}" chart/influxdb \
   --namespace $NAMESPACE \
   --set influxdb.image.repo=$IMAGE_INFLUXDB \
   --set influxdb.image.tag=$TAG \

--- a/k8s/magento/README.md
+++ b/k8s/magento/README.md
@@ -278,8 +278,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/magento \
-    --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/magento \
     --namespace "${NAMESPACE}" \
     --set persistence.storageClass="${DEFAULT_STORAGE_CLASS}" \
     --set magento.image.repo="${IMAGE_MAGENTO}" \

--- a/k8s/mariadb-galera/README.md
+++ b/k8s/mariadb-galera/README.md
@@ -244,8 +244,7 @@ Use `helm template` to expand the template. We recommend that you save
 the expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/mariadb-galera \
-  --name "$APP_INSTANCE_NAME" \
+helm template "$APP_INSTANCE_NAME" chart/mariadb-galera \
   --namespace "$NAMESPACE" \
   --set mariadb.image.repo="$IMAGE_MARIADB" \
   --set mariadb.image.tag="$TAG" \

--- a/k8s/mediawiki/README.md
+++ b/k8s/mediawiki/README.md
@@ -267,8 +267,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/mediawiki \
-    --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/mediawiki \
     --namespace "${NAMESPACE}" \
     --set mediawiki.image.repo="${IMAGE_MEDIAWIKI}" \
     --set mediawiki.image.tag="${TAG}" \

--- a/k8s/memcached/README.md
+++ b/k8s/memcached/README.md
@@ -396,8 +396,7 @@ Console, or using the command line.
     Use `helm template` to expand the template.
 
     ```shell
-    helm template chart/memcached \
-      --name "$APP_INSTANCE_NAME" \
+    helm template "$APP_INSTANCE_NAME" chart/memcached \
       --namespace "$NAMESPACE" \
       --set memcached.replicas="$REPLICAS" \
       --set memcached.image.repo="$IMAGE_MEMCACHED" \

--- a/k8s/nuclio/README.md
+++ b/k8s/nuclio/README.md
@@ -272,8 +272,7 @@ Use `helm template` to expand the template. We recommend that you save the
 expanded manifest file for future updates to the app.
 
 ```shell
-helm template chart/nuclio \
-  --name ${APP_INSTANCE_NAME} \
+helm template "${APP_INSTANCE_NAME}" chart/nuclio \
   --namespace ${NAMESPACE} \
   --set controller.image.repo=${IMAGE_CONTROLLER} \
   --set controller.image.tag=${TAG} \

--- a/k8s/orientdb/README.md
+++ b/k8s/orientdb/README.md
@@ -194,8 +194,7 @@ To expand the template, use `helm template`. We recommend that you save the
 expanded manifest file for future updates to your app.
 
 ```shell
-helm template chart/orientdb \
-  --name "${APP_INSTANCE_NAME}" \
+helm template "${APP_INSTANCE_NAME}" chart/orientdb \
   --namespace "${NAMESPACE}" \
   --set orientdb.image.repo="${IMAGE_ORIENTDB}" \
   --set orientdb.image.tag="${TAG}" \


### PR DESCRIPTION
Helm template command no longer accepts the `--name` flag. Name is now a required positional argument for helm. See: https://helm.sh/docs/faq/changes_since_helm2/

Some were fixed in this PR: https://github.com/GoogleCloudPlatform/click-to-deploy/pull/1225
This fixes the rest.
<!--- /gcbrun -->
