### PR TITLE
K8S - Joomla - Fix tests, add checkdb step

### DIFF
--- a/k8s/joomla/README.md
+++ b/k8s/joomla/README.md
@@ -184,14 +184,14 @@ It is advised to use stable image reference which you can find on
 Example:
 
 ```shell
-export TAG="3.9.15-20200311-092327"
+export TAG="4.2.8-20200311-092327"
 ```
 
 Alternatively you can use short tag which points to the latest image for selected version.
 > Warning: this tag is not stable and referenced image might change over time.
 
 ```shell
-export TAG="3.9"
+export TAG="4.2"
 ```
 
 Configure the container images:

--- a/k8s/joomla/apptest/tester/Dockerfile
+++ b/k8s/joomla/apptest/tester/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget -q -O /bin/kubectl \
-    https://storage.googleapis.com/kubernetes-release/release/v1.12.0/bin/linux/amd64/kubectl \
+    https://storage.googleapis.com/kubernetes-release/release/v1.24.5/bin/linux/amd64/kubectl \
       && chmod 755 /bin/kubectl
 
 COPY tests /tests

--- a/k8s/joomla/apptest/tester/tests/common/joomla-suite.yaml
+++ b/k8s/joomla/apptest/tester/tests/common/joomla-suite.yaml
@@ -1,27 +1,20 @@
 actions:
 
-# TODO(wgrzelak): Add actions to test authorization with correct credentials,
-# incorrect credentials and without credentials.
-# Example: https://github.com/GoogleCloudPlatform/click-to-deploy/blob/d242d7eaa4fcce804f6a9d03cf569a901a5cf9be/k8s/influxdb/apptest/tester/tests/basic-suite.yaml.template#L18-L33
-
-- name: Site address should be 200 OK (service DNS)
-  httpTest:
-    url: http://{{ .Env.APP_INSTANCE_NAME }}-joomla-svc
+- name: Check Home page
+  bashTest:
+    script: curl -L "http://${APP_INSTANCE_NAME}-joomla-svc"
     expect:
-      statusCode:
-        equals: 200
-      bodyText:
-        html:
-          title:
-            equals: 'Home'
+      stdout:
+        contains: 'Home'
+      exitCode:
+        equals: 0
 
-- name: Admin URL should be 200 OK (service DNS)
-  httpTest:
-    url: http://{{ .Env.APP_INSTANCE_NAME }}-joomla-svc/administrator
+- name: Check Admin page
+  bashTest:
+    script: curl -L "http://${APP_INSTANCE_NAME}-joomla-svc/administrator"
     expect:
-      statusCode:
-        equals: 200
-      bodyText:
-        html:
-          title:
-            equals: 'Joomla! - Administration'
+      stdout:
+        contains: 'Joomla! - Administration'
+      exitCode:
+        equals: 0
+

--- a/k8s/joomla/apptest/tester/tests/external/exporter-external-suite.yaml
+++ b/k8s/joomla/apptest/tester/tests/external/exporter-external-suite.yaml
@@ -1,12 +1,9 @@
 actions:
 
-- name: Can not access Apache /server-status externally
-  httpTest:
-    url: http://{{ .Env.EXTERNAL_IP }}/server-status
+- name: Check server status
+  bashTest:
+    script: curl -L "http://${EXTERNAL_IP}/server-status"
     expect:
-      statusCode:
-        equals: 403
-      bodyText:
-        html:
-          title:
-            equals: '403 Forbidden'
+      stdout:
+        contains: '403 Forbidden''
+

--- a/k8s/joomla/apptest/tester/tests/external/joomla-external-suite.yaml
+++ b/k8s/joomla/apptest/tester/tests/external/joomla-external-suite.yaml
@@ -1,15 +1,14 @@
 actions:
 
-- name: Site address should be 200 OK (external IP)
-  httpTest:
-    url: http://{{ .Env.EXTERNAL_IP }}
+- name: Check Home page
+  bashTest:
+    script: curl -L "http://${EXTERNAL_IP}"
     expect:
-      statusCode:
-        equals: 200
-      bodyText:
-        html:
-          title:
-            equals: 'Home'
+      stdout:
+        contains: 'Home'
+      exitCode:
+        equals: 0
+
 
 - name: Site address should be 200 OK (external IP) (TLS)
   bashTest:

--- a/k8s/joomla/chart/joomla/templates/_helpers/pods.tpl
+++ b/k8s/joomla/chart/joomla/templates/_helpers/pods.tpl
@@ -1,0 +1,15 @@
+{{- define "joomla.init_container.check_db" }}
+- name: check-db
+  image: busybox:1.35
+  imagePullPolicy: IfNotPresent
+  command:
+    - sh
+    - -c
+    - |
+      echo 'Waiting for MariaDB to become ready...'
+      until printf "." && nc -z -w 2 "{{ .Release.Name }}-mariadb-svc" 3306; do
+        sleep 2;
+      done;
+      echo 'MariaDB is ready'
+{{- end }}
+

--- a/k8s/joomla/chart/joomla/templates/joomla-statefulset.yaml
+++ b/k8s/joomla/chart/joomla/templates/joomla-statefulset.yaml
@@ -17,6 +17,8 @@ spec:
     metadata:
       labels: *JoomlaDeploymentLabels
     spec:
+      initContainers:
+        {{- include "joomla.init_container.check_db" . | indent 8 }}
       containers:
       - image: {{ .Values.joomla.image.repo }}:{{ .Values.joomla.image.tag }}
         name: joomla


### PR DESCRIPTION
```
DEPLOYER SMOKE_TEST I0307 10:57:03.787148       7 main.go:86] >>> Running /tests/common/db-suite.yaml
DEPLOYER SMOKE_TEST I0307 10:57:03.788461       7 main.go:136]  >   0: Connect to a database (as root user)
DEPLOYER SMOKE_TEST I0307 10:57:03.829860       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.829896       7 main.go:136]  >   1: Can connect to a database (as joomla user)
DEPLOYER SMOKE_TEST I0307 10:57:03.852797       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.852830       7 main.go:136]  >   2: Can not connect to a database with incorrect credentials
DEPLOYER SMOKE_TEST I0307 10:57:03.875579       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.875602       7 main.go:136]  >   3: Can not connect to a database without credentials
DEPLOYER SMOKE_TEST I0307 10:57:03.896694       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896712       7 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896717       7 main.go:123]  >   0: Connect to a database (as root user): PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896721       7 main.go:123]  >   1: Can connect to a database (as joomla user): PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896724       7 main.go:123]  >   2: Can not connect to a database with incorrect credentials: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896727       7 main.go:123]  >   3: Can not connect to a database without credentials: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.896733       7 main.go:97] >>> SUMMARY: All passed
DEPLOYER SMOKE_TEST + for test in /tests/common/*
DEPLOYER SMOKE_TEST + testrunner -logtostderr --test_spec=/tests/common/exporter-suite.yaml
DEPLOYER SMOKE_TEST I0307 10:57:03.901937      18 main.go:86] >>> Running /tests/common/exporter-suite.yaml
DEPLOYER SMOKE_TEST I0307 10:57:03.903281      18 main.go:136]  >   0: Check MySQL /metrics HTTP endpoint
DEPLOYER SMOKE_TEST I0307 10:57:03.950360      18 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.950602      18 main.go:136]  >   1: MySQL Exporter can collect MySQL server metrics
DEPLOYER SMOKE_TEST I0307 10:57:03.993908      18 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:03.994154      18 main.go:136]  >   2: Check Apache /metrics endpoint
DEPLOYER SMOKE_TEST I0307 10:57:04.015432      18 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.015457      18 main.go:136]  >   3: Apache Exporter can collect Apache server metrics
DEPLOYER SMOKE_TEST I0307 10:57:04.035199      18 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035222      18 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035229      18 main.go:123]  >   0: Check MySQL /metrics HTTP endpoint: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035234      18 main.go:123]  >   1: MySQL Exporter can collect MySQL server metrics: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035240      18 main.go:123]  >   2: Check Apache /metrics endpoint: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035245      18 main.go:123]  >   3: Apache Exporter can collect Apache server metrics: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.035252      18 main.go:97] >>> SUMMARY: All passed
DEPLOYER SMOKE_TEST + for test in /tests/common/*
DEPLOYER SMOKE_TEST + testrunner -logtostderr --test_spec=/tests/common/joomla-suite.yaml
DEPLOYER SMOKE_TEST I0307 10:57:04.041044      33 main.go:86] >>> Running /tests/common/joomla-suite.yaml
DEPLOYER SMOKE_TEST I0307 10:57:04.042080      33 main.go:136]  >   0: Check Home page
DEPLOYER SMOKE_TEST I0307 10:57:04.118171      33 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.118291      33 main.go:136]  >   1: Check Admin page
DEPLOYER SMOKE_TEST I0307 10:57:04.185941      33 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.185965      33 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.185973      33 main.go:123]  >   0: Check Home page: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.185980      33 main.go:123]  >   1: Check Admin page: PASSED
DEPLOYER SMOKE_TEST I0307 10:57:04.185987      33 main.go:97] >>> SUMMARY: All passed
```
