### PR TITLE
K8S - Neo4j - Fix chart, update version

### DIFF
--- a/k8s/neo4j-ce/Makefile
+++ b/k8s/neo4j-ce/Makefile
@@ -4,12 +4,14 @@ include ../var.Makefile
 include ../images.Makefile
 
 CHART_NAME := neo4j-ce
-APP_ID ?= $(CHART_NAME)
 
-TRACK ?= 4.4
+# APP_ID can not start from neo4j-
+APP_ID ?= $(shell echo $(CHART_NAME) | sed 's/^neo4j-/neo4j/')
+
+TRACK ?= 5.5
 
 SOURCE_REGISTRY ?= marketplace.gcr.io/google
-IMAGE_NEO4J_CE ?= $(SOURCE_REGISTRY)/neo4j4:$(TRACK)
+IMAGE_NEO4J_CE ?= $(SOURCE_REGISTRY)/neo4j5:$(TRACK)
 
 # Main image
 image-$(CHART_NAME) := $(call get_sha256,$(IMAGE_NEO4J_CE))

--- a/k8s/neo4j-ce/README.md
+++ b/k8s/neo4j-ce/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-Neo4j Community Edition 4.x is an open source graph database management system,
+Neo4j Community Edition 5.x is an open source graph database management system,
 written in Java. It provides a web dashboard for managing data and users. You
 can access its service by using an HTTP REST API or the Bolt binary protocol.
 
@@ -132,9 +132,9 @@ export NAMESPACE=default
 Configure the container image:
 
 ```shell
-TAG=4.3
+TAG=5.5
 export IMAGE_REGISTRY="marketplace.gcr.io/google"
-export IMAGE_NEO4J_CE="${IMAGE_REGISTRY}/neo4j4"
+export IMAGE_NEO4J_CE="${IMAGE_REGISTRY}/neo4j5"
 ```
 
 For persistent disk provisioning of the Neo4j CE servers, you must:

--- a/k8s/neo4j-ce/apptest/deployer/neo4j-ce/templates/tester.yaml
+++ b/k8s/neo4j-ce/apptest/deployer/neo4j-ce/templates/tester.yaml
@@ -28,7 +28,7 @@ spec:
     - name: APP_INSTANCE_NAME
       value: {{ .Release.Name }}
     - name: APP_SERVICE
-      value: "{{ .Release.Namespace }}-neo4j-svc.{{ .Release.Namespace }}.svc.cluster.local"
+      value: "{{ .Release.Name }}-neo4j-svc.{{ .Release.Namespace }}.svc.cluster.local"
     # Credentials for neo4j root user.
     - name: ROOT_USERNAME
       valueFrom:

--- a/k8s/neo4j-ce/apptest/tester/Dockerfile
+++ b/k8s/neo4j-ce/apptest/tester/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x \
         openjdk-11-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L -o cypher-shell.deb https://github.com/neo4j/cypher-shell/releases/download/4.0.1/cypher-shell_4.0.1_all.deb \
+RUN curl -L -o cypher-shell.deb https://github.com/neo4j/cypher-shell/releases/download/4.2.2/cypher-shell_4.2.2_all.deb \
     && dpkg -i cypher-shell.deb \
     && rm -f cypher-shell.deb
 


### PR DESCRIPTION
```
+ shopt -s nullglob
+ for test in /tests/*
+ testrunner -logtostderr --test_spec=/tests/cli-suite.yaml
I0313 14:44:16.430112       7 main.go:86] >>> Running /tests/cli-suite.yaml
I0313 14:44:16.433080       7 main.go:136]  >   0: Bad authentication via CLI
I0313 14:44:17.705928       7 main.go:141]  PASSED
I0313 14:44:17.705953       7 main.go:136]  >   1: Create a node via CLI
I0313 14:44:21.139506       7 main.go:141]  PASSED
I0313 14:44:21.139530       7 main.go:136]  >   2: Get nodes via CLI
I0313 14:44:22.515858       7 main.go:141]  PASSED
I0313 14:44:22.515936       7 main.go:117]  >> Summary: PASSED
I0313 14:44:22.515944       7 main.go:123]  >   0: Bad authentication via CLI: PASSED
I0313 14:44:22.515963       7 main.go:123]  >   1: Create a node via CLI: PASSED
I0313 14:44:22.515972       7 main.go:123]  >   2: Get nodes via CLI: PASSED
I0313 14:44:22.515979       7 main.go:97] >>> SUMMARY: All passed
+ for test in /tests/*
+ testrunner -logtostderr --test_spec=/tests/http-suite.yaml
I0313 14:44:22.521628     135 main.go:86] >>> Running /tests/http-suite.yaml
I0313 14:44:22.523067     135 main.go:136]  >   0: Check if API available
I0313 14:44:22.584396     135 main.go:141]  PASSED
I0313 14:44:22.584428     135 main.go:136]  >   1: Create a node via API
I0313 14:44:22.752141     135 main.go:141]  PASSED
I0313 14:44:22.752194     135 main.go:136]  >   2: Get nodes via API
I0313 14:44:22.819688     135 main.go:141]  PASSED
I0313 14:44:22.819711     135 main.go:117]  >> Summary: PASSED
I0313 14:44:22.819717     135 main.go:123]  >   0: Check if API available: PASSED
I0313 14:44:22.819722     135 main.go:123]  >   1: Create a node via API: PASSED
I0313 14:44:22.819726     135 main.go:123]  >   2: Get nodes via API: PASSED
I0313 14:44:22.819731     135 main.go:97] >>> SUMMARY: All passed
```