### PR TITLE
K8S - Tikv - Update version

### DIFF
--- a/k8s/tikv/Makefile
+++ b/k8s/tikv/Makefile
@@ -10,16 +10,16 @@ VERIFY_WAIT_TIMEOUT = 1800
 
 SOURCE_REGISTRY ?= marketplace.gcr.io/google
 
-TRACK ?= 5.3
-METRICS_EXPORTER_TAG ?= v0.5.1
+TRACK ?= 6.5
+METRICS_EXPORTER_TAG ?= v0.11.1-gke.1
 
-IMAGE_TIKV ?= $(SOURCE_REGISTRY)/tikv5:$(TRACK)
+IMAGE_TIKV ?= $(SOURCE_REGISTRY)/tikv6:$(TRACK)
 
 # Main image
 image-$(CHART_NAME) := $(call get_sha256,$(IMAGE_TIKV))
 
 # Prometheus-to-SD
-IMAGE_PROMETHEUS_TO_SD ?= k8s.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
+IMAGE_PROMETHEUS_TO_SD ?= gke.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
 # List of images used in application
 ADDITIONAL_IMAGES := prometheus-to-sd

--- a/k8s/tikv/README.md
+++ b/k8s/tikv/README.md
@@ -119,15 +119,15 @@ It is advised to use a stable image reference, which you can find on:
 For example:
 
 ```shell
-export TIKV_TRACK=5.3
-export METRICS_EXPORTER_TAG=0.5
+export TIKV_TRACK=6.5
+export METRICS_EXPORTER_TAG=v0.11.1-gke.1
 ```
 
 Configure the container images:
 
 ```shell
-export IMAGE_TIKV=marketplace.gcr.io/google/tikv5
-export IMAGE_METRICS_EXPORTER=k8s.gcr.io/prometheus-to-sd:${METRICS_EXPORTER_TAG}
+export IMAGE_TIKV=marketplace.gcr.io/google/tikv6
+export IMAGE_METRICS_EXPORTER=gke.gcr.io/prometheus-to-sd:${METRICS_EXPORTER_TAG}
 ```
 
 By default, TiKV deployment has 3 replica, but you can choose to set the number of replicas.


### PR DESCRIPTION
```
+ shopt -s nullglob
+ for test in /tests/*
+ testrunner -logtostderr --test_spec=/tests/basic-suite.yaml
I0322 11:57:09.654988       7 main.go:86] >>> Running /tests/basic-suite.yaml
I0322 11:57:09.656919       7 main.go:136]  >   0: kubectl smoke test
I0322 11:57:09.730545       7 main.go:141]  PASSED
I0322 11:57:09.730585       7 main.go:136]  >   1: Wait for the PD get ready
I0322 11:57:10.183729       7 main.go:141]  PASSED
I0322 11:57:10.183767       7 main.go:136]  >   2: Wait for the TiKV get ready
I0322 11:57:10.447446       7 main.go:141]  PASSED
I0322 11:57:10.447493       7 main.go:136]  >   3: Run /tikvtest
I0322 11:57:10.637961       7 main.go:141]  PASSED
I0322 11:57:10.638003       7 main.go:136]  >   4: Check cluster health
I0322 11:57:10.673094       7 main.go:141]  PASSED
I0322 11:57:10.673205       7 main.go:117]  >> Summary: PASSED
I0322 11:57:10.673212       7 main.go:123]  >   0: kubectl smoke test: PASSED
I0322 11:57:10.673217       7 main.go:123]  >   1: Wait for the PD get ready: PASSED
I0322 11:57:10.673237       7 main.go:123]  >   2: Wait for the TiKV get ready: PASSED
I0322 11:57:10.673241       7 main.go:123]  >   3: Run /tikvtest: PASSED
I0322 11:57:10.673247       7 main.go:123]  >   4: Check cluster health: PASSED
I0322 11:57:10.673253       7 main.go:97] >>> SUMMARY: All passed

```
