### PR TITLE
K8S -Prometheus, Redis-ha - Add statefulsets name constraints

### DIFF
--- a/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
+++ b/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{- define "prometheus.alertmanagerName" -}}
+{{- .Release.Name | trunc 14 -}}
+{{- end -}}
+
+{{- define "prometheus.prometheusName" -}}
+{{- .Release.Name | trunc 16 -}}
+{{- end -}}
+

--- a/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
+++ b/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "prometheus.alertmanagerName" -}}
-{{- .Release.Name | trunc 14 -}}
+{{- .Release.Name | trunc 17 -}}
 {{- end -}}
 
 {{- define "prometheus.prometheusName" -}}

--- a/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
+++ b/k8s/prometheus/chart/prometheus/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "prometheus.alertmanagerName" -}}
-{{- .Release.Name | trunc 17 -}}
+{{- .Release.Name | trunc 14 -}}
 {{- end -}}
 
 {{- define "prometheus.prometheusName" -}}

--- a/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
+++ b/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-alertmanager
+  name: {{ template "prometheus.alertmanagerName" . }}-alertmanager
   labels: &Labels
     k8s-app: alertmanager
     app.kubernetes.io/name: "{{ .Release.Name }}"
@@ -80,7 +80,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Release.Name }}-alertmanager-data
+      name: {{ template "prometheus.alertmanagerName" . }}-alertmanager-data
     spec:
       storageClassName: "{{ .Values.prometheus.storageClass }}"
       accessModes:

--- a/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
+++ b/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
@@ -80,7 +80,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:
   - metadata:
-      name: {{ template "prometheus.alertmanagerName" . }}-alertmanager-data
+      name: {{ template "prometheus.alertmanagerName" . }}-amanager-data
     spec:
       storageClassName: "{{ .Values.prometheus.storageClass }}"
       accessModes:

--- a/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
+++ b/k8s/prometheus/chart/prometheus/templates/alertmanager-statefulset.yaml
@@ -54,7 +54,7 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
-            - name: {{ .Release.Name }}-alertmanager-data
+            - name: {{ template "prometheus.alertmanagerName" . }}-alertmanager-data
               mountPath: "/data"
               subPath: ""
           resources:
@@ -80,7 +80,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:
   - metadata:
-      name: {{ template "prometheus.alertmanagerName" . }}-amanager-data
+      name: {{ template "prometheus.alertmanagerName" . }}-alertmanager-data
     spec:
       storageClassName: "{{ .Values.prometheus.storageClass }}"
       accessModes:

--- a/k8s/prometheus/chart/prometheus/templates/prometheus-statefulset.yaml
+++ b/k8s/prometheus/chart/prometheus/templates/prometheus-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /etc/config
-            - name: {{ .Release.Name }}-prometheus-data
+            - name: {{ template "prometheus.prometheusName" . }}-prometheus-data
               mountPath: /data
               subPath: ""
       terminationGracePeriodSeconds: 300

--- a/k8s/prometheus/chart/prometheus/templates/prometheus-statefulset.yaml
+++ b/k8s/prometheus/chart/prometheus/templates/prometheus-statefulset.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .Release.Name }}-prometheus
+  name: {{ template "prometheus.prometheusName" . }}-prometheus
   labels: &Labels
     k8s-app: prometheus
     app.kubernetes.io/name: "{{ .Release.Name }}"
@@ -82,7 +82,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
   volumeClaimTemplates:
   - metadata:
-      name: {{ .Release.Name }}-prometheus-data
+      name: {{ template "prometheus.prometheusName" . }}-prometheus-data
       labels: *Labels
     spec:
       storageClassName: "{{ .Values.prometheus.storageClass }}"

--- a/k8s/redis-ha/chart/redis-ha/templates/_helpers.tpl
+++ b/k8s/redis-ha/chart/redis-ha/templates/_helpers.tpl
@@ -11,15 +11,10 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "redis-ha.fullname" -}}
-{{- if .Values.fullnameOverride -}}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 24| trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- else -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 24 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Can't publish these solutions now, errors are:
```
56s         
Warning   
ProvisioningFailed     
persistentvolumeclaim/apptest-7usca8m9-redis-ha-data-apptest-7usca8m9-redis-ha-server-0   failed to provision volume with StorageClass "apptest-7usca8m9-apptest-7usca8m9-redis-persistence-storageclass": rpc error: code = InvalidArgument desc = CreateVolume failed to create single zonal disk pvc-07381310-7eba-437b-896b-407d82eafee2: failed to insert zonal disk: unknown Insert disk error: googleapi: Error 400: Invalid value for field 'resource.labels': ''. Label value 'apptest-7usca8m9-redis-ha-data-apptest-7usca8m9-redis-ha-server-0' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid
```

```
0s         
 Warning   
ProvisioningFailed     
persistentvolumeclaim/apptest-4b7v4lax-alertmanager-data-apptest-4b7v4lax-alertmanager-0   failed to provision volume with StorageClass "apptest-4b7v4lax-apptest-4b7v4lax-prometheus-storageclass": rpc error: code = InvalidArgument desc = CreateVolume failed to create single zonal disk pvc-82f87f62-56ab-497c-8567-62407b01ddc9: failed to insert zonal disk: unknown Insert disk error: googleapi: Error 400: Invalid value for field 'resource.labels': ''. Label value 'apptest-4b7v4lax-alertmanager-data-apptest-4b7v4lax-alertmanager-0' violates format constraints. The value can only contain lowercase letters, numeric characters, underscores and dashes. The value can be at most 63 characters long. International characters are allowed., invalid
```
