### PR TITLE
K8S - Hydra - Fix psql statefulset

### DIFF
--- a/k8s/hydra/README.md
+++ b/k8s/hydra/README.md
@@ -163,6 +163,13 @@ export HYDRA_MEMORY_REQUEST=128Mi
 export HYDRA_CPU_REQUEST=100m
 ```
 
+Set the persistent disks size. The default disks size is "5Gi".
+
+```shell
+export DEFAULT_STORAGE_CLASS="standard" # provide your StorageClass name if not "standard"
+export PSQL_PERSISTENT_DISK_SIZE="8Gi"
+```
+
 Set or generate the password for the PostgreSQL service:
 
 ```shell
@@ -258,6 +265,8 @@ helm template "${APP_INSTANCE_NAME}" chart/hydra \
   --set postgresql.image="${IMAGE_POSTGRESQL}" \
   --set postgresql.exporter.image="${IMAGE_POSTGRESQL_EXPORTER}" \
   --set postgresql.password="${POSTGRES_PASSWORD}" \
+  --set postgresql.persistence.storageClass="${DEFAULT_STORAGE_CLASS}" \
+  --set postgresql.persistence.size="${PSQL_PERSISTENT_DISK_SIZE}" \
   --set hydra.memoryRequest="${HYDRA_MEMORY_REQUEST}" \
   --set hydra.cpuRequest="${HYDRA_CPU_REQUEST}" \
   --set ingress.public.enabled="${INGRESS_PUBLIC_ENABLED}" \

--- a/k8s/hydra/chart/hydra/templates/postgresql-statefulset.yaml
+++ b/k8s/hydra/chart/hydra/templates/postgresql-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
-      storageClassName: standard
+      storageClassName: {{ .Values.postgresql.persistence.storageClass }}
       resources:
         requests:
           storage: {{ .Values.postgresql.persistence.size }}

--- a/k8s/hydra/chart/hydra/values.yaml
+++ b/k8s/hydra/chart/hydra/values.yaml
@@ -13,6 +13,7 @@ postgresql:
   postgresDatabase: hydra
 
   persistence:
+    storageClass: standard
     size: 8Gi
 
 

--- a/k8s/hydra/schema.yaml
+++ b/k8s/hydra/schema.yaml
@@ -47,6 +47,14 @@ properties:
     type: string
     x-google-marketplace:
       type: NAMESPACE
+  postgresql.persistence.storageClass:
+    type: string
+    title: PostgreSQL StorageClass
+    description: You can choose an existing StorageClass or create a new one.
+    x-google-marketplace:
+      type: STORAGE_CLASS
+      storageClass:
+        type: SSD
   postgresql.persistence.size:
     type: string
     title: PostgreSQL storage size


### PR DESCRIPTION
```
DEPLOYER SMOKE_TEST I0413 11:26:59.745454       7 main.go:86] >>> Running /tests/basic-suite.yaml
DEPLOYER SMOKE_TEST I0413 11:26:59.746247       7 main.go:136]  >   0: Hydra Liveness Check
DEPLOYER SMOKE_TEST I0413 11:26:59.787987       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.788023       7 main.go:136]  >   1: Hydra Readiness Check
DEPLOYER SMOKE_TEST I0413 11:26:59.814225       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.814255       7 main.go:136]  >   2: Is Hydra /metrics/prometheus HTTP endpoint working for Prometheus metrics
DEPLOYER SMOKE_TEST I0413 11:26:59.856037       7 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.856064       7 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.856068       7 main.go:123]  >   0: Hydra Liveness Check: PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.856073       7 main.go:123]  >   1: Hydra Readiness Check: PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.856076       7 main.go:123]  >   2: Is Hydra /metrics/prometheus HTTP endpoint working for Prometheus metrics: PASSED
DEPLOYER SMOKE_TEST I0413 11:26:59.856081       7 main.go:97] >>> SUMMARY: All passed
DEPLOYER SMOKE_TEST + for test in /tests/*
DEPLOYER SMOKE_TEST + testrunner -logtostderr --test_spec=/tests/postgresql-exporter-suite.yaml
DEPLOYER SMOKE_TEST I0413 11:26:59.860519      20 main.go:86] >>> Running /tests/postgresql-exporter-suite.yaml
DEPLOYER SMOKE_TEST I0413 11:26:59.861099      20 main.go:136]  >   0: Prometheus metrics availability
DEPLOYER SMOKE_TEST I0413 11:27:19.906074      20 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:27:19.906097      20 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:19.906102      20 main.go:123]  >   0: Prometheus metrics availability: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:19.906107      20 main.go:97] >>> SUMMARY: All passed
DEPLOYER SMOKE_TEST + for test in /tests/*
DEPLOYER SMOKE_TEST + testrunner -logtostderr --test_spec=/tests/postgresql-suite.yaml
DEPLOYER SMOKE_TEST I0413 11:27:19.910985      29 main.go:86] >>> Running /tests/postgresql-suite.yaml
DEPLOYER SMOKE_TEST I0413 11:27:19.911764      29 main.go:136]  >   0: DB operations - create table
DEPLOYER SMOKE_TEST I0413 11:27:19.984728      29 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:27:19.984792      29 main.go:136]  >   1: DB operations - check table
DEPLOYER SMOKE_TEST I0413 11:27:20.048472      29 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.048498      29 main.go:136]  >   2: DB operations - insert into table
DEPLOYER SMOKE_TEST I0413 11:27:20.111103      29 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.111127      29 main.go:136]  >   3: DB operations - cleanup table
DEPLOYER SMOKE_TEST I0413 11:27:20.173346      29 main.go:141]  PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173368      29 main.go:117]  >> Summary: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173372      29 main.go:123]  >   0: DB operations - create table: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173382      29 main.go:123]  >   1: DB operations - check table: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173385      29 main.go:123]  >   2: DB operations - insert into table: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173389      29 main.go:123]  >   3: DB operations - cleanup table: PASSED
DEPLOYER SMOKE_TEST I0413 11:27:20.173394      29 main.go:97] >>> SUMMARY: All passed
```
