### PR TITLE
K8S - Cassandra - Update probes, fix hardcoded cluster seeds

### DIFF
--- a/k8s/cassandra/apptest/tester/Dockerfile
+++ b/k8s/cassandra/apptest/tester/Dockerfile
@@ -11,11 +11,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-setuptools \
     && pip install --upgrade pip \
     && python -m pip install --upgrade wheel \
-    && python -m pip install cqlsh \
+    && python -m pip install cqlsh futures \
     && rm -rf /var/lib/apt/lists/*
 
 RUN wget -q -O /bin/kubectl \
-    https://storage.googleapis.com/kubernetes-release/release/v1.23.15/bin/linux/amd64/kubectl \
+    https://storage.googleapis.com/kubernetes-release/release/v1.24.10/bin/linux/amd64/kubectl \
       && chmod 755 /bin/kubectl
 
 COPY tests/basic-suite.yaml /tests/basic-suite.yaml

--- a/k8s/cassandra/chart/cassandra/templates/cassandra-statefulset.yaml
+++ b/k8s/cassandra/chart/cassandra/templates/cassandra-statefulset.yaml
@@ -30,8 +30,14 @@ spec:
           value: {{ .Release.Name }}-cassandra-svc
         - name: CASSANDRA_PROMETHEUS_ENABLED
           value: 'true'
+        {{- $fullName := .Release.Name }}
+        {{- $releaseName := .Release.Namespace }}
+        {{- $initialCluster := list }}
+        {{- range $e, $i := until (int .Values.cassandra.replicas) }}
+        {{- $initialCluster = append $initialCluster (printf "%s-cassandra-%d.%s-cassandra-svc.%s.svc.cluster.local" $fullName $i $fullName $releaseName) }}
+        {{- end }}
         - name: CASSANDRA_SEEDS
-          value: {{ .Release.Name }}-cassandra-0.{{ .Release.Name }}-cassandra-svc.{{ .Release.Namespace }}.svc.cluster.local, {{ .Release.Name }}-cassandra-1.{{ .Release.Name }}-cassandra-svc.{{ .Release.Namespace }}.svc.cluster.local, {{ .Release.Name }}-cassandra-2.{{ .Release.Name }}-cassandra-svc.{{ .Release.Namespace }}.svc.cluster.local
+          value: {{ printf "%s" (join "," $initialCluster) | quote }}
         ports:
         - name: pure-intra
           containerPort: 7000
@@ -60,13 +66,17 @@ spec:
             command: [ "/bin/sh", "-c", "nodetool -Dcom.sun.jndi.rmiURLParsing=legacy status" ]
           initialDelaySeconds: 90
           periodSeconds: 30
-          timeoutSeconds: 25
+          timeoutSeconds: 30
+          successThreshold: 1
+          failureThreshold: 5
         readinessProbe:
           exec:
             command: [ "/bin/sh", "-c", "nodetool -Dcom.sun.jndi.rmiURLParsing=legacy status | grep -E \"^UN\\s+${POD_IP}\"" ]
           initialDelaySeconds: 90
           periodSeconds: 30
-          timeoutSeconds: 25
+          timeoutSeconds: 30
+          successThreshold: 1
+          failureThreshold: 10
         lifecycle:
           preStop:
             exec:


### PR DESCRIPTION
```
I0419 10:32:27.639288       6 main.go:86] >>> Running /tests/basic-suite.yaml
I0419 10:32:27.640221       6 main.go:136]  >   0: There are exactly 3 nodes in a cluster
I0419 10:32:27.952913       6 main.go:141]  PASSED
I0419 10:32:27.953153       6 main.go:136]  >   1: Execute CQL query
I0419 10:32:37.377866       6 main.go:141]  PASSED
I0419 10:32:37.377968       6 main.go:136]  >   2: Cluster is connected
I0419 10:32:48.107007       6 main.go:141]  PASSED
I0419 10:32:48.107038       6 main.go:136]  >   3: Can read/write data between nodes
I0419 10:33:02.702186       6 main.go:141]  PASSED
I0419 10:33:02.702242       6 main.go:136]  >   4: Prometheus metrics are exported
I0419 10:35:31.024722       6 main.go:141]  PASSED
I0419 10:35:31.024820       6 main.go:117]  >> Summary: PASSED
I0419 10:35:31.024851       6 main.go:123]  >   0: There are exactly 3 nodes in a cluster: PASSED
I0419 10:35:31.024870       6 main.go:123]  >   1: Execute CQL query: PASSED
I0419 10:35:31.024903       6 main.go:123]  >   2: Cluster is connected: PASSED
I0419 10:35:31.024931       6 main.go:123]  >   3: Can read/write data between nodes: PASSED
I0419 10:35:31.024950       6 main.go:123]  >   4: Prometheus metrics are exported: PASSED
I0419 10:35:31.024970       6 main.go:97] >>> SUMMARY: All passed
```
