### PR TITLE
Remove Stackdriver Metrics Exporter from nginx k8s click-to-deploy

### DIFF
--- a/k8s/nginx/Makefile
+++ b/k8s/nginx/Makefile
@@ -9,40 +9,28 @@ APP_ID ?= $(CHART_NAME)
 TRACK ?= 1.25
 
 EXPORTER_TAG ?= 0.11
-METRICS_EXPORTER_TAG ?= v0.11.1-gke.1
 
 SOURCE_REGISTRY ?= marketplace.gcr.io/google
 IMAGE_NGINX ?= $(SOURCE_REGISTRY)/nginx1:$(TRACK)
 IMAGE_NGINX_EXPORTER = $(SOURCE_REGISTRY)/nginx-exporter0:$(EXPORTER_TAG)
 IMAGE_DEBIAN ?= $(SOURCE_REGISTRY)/c2d-debian11:latest
-IMAGE_PROMETHEUS_TO_SD ?= gke.gcr.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 
 
 # Main image
 image-$(CHART_NAME) := $(call get_sha256,$(IMAGE_NGINX))
 
 # List of images used in application
-ADDITIONAL_IMAGES := debian nginx-exporter prometheus-to-sd
+ADDITIONAL_IMAGES := debian nginx-exporter
 
 # Additional images variable names should correspond with ADDITIONAL_IMAGES list
 image-debian :=  $(call get_sha256,$(IMAGE_DEBIAN))
 image-nginx-exporter := $(call get_sha256,$(IMAGE_NGINX_EXPORTER))
-image-prometheus-to-sd := $(call get_sha256,$(IMAGE_PROMETHEUS_TO_SD))
 
 C2D_CONTAINER_RELEASE := $(call get_c2d_release,$(image-$(CHART_NAME)))
 
 BUILD_ID := $(shell date --utc +%Y%m%d-%H%M%S)
 RELEASE ?= $(C2D_CONTAINER_RELEASE)-$(BUILD_ID)
 NAME ?= $(APP_ID)-1
-
-# Additional variables
-ifdef METRICS_EXPORTER_ENABLED
-  METRICS_EXPORTER_ENABLED_FIELD = , "metrics.exporter.enabled": $(METRICS_EXPORTER_ENABLED)
-endif
-
-ifdef CURATED_METRICS_EXPORTER_ENABLED
-  CURATED_METRICS_EXPORTER_ENABLED_FIELD = , "metrics.curatedExporter.enabled": $(CURATED_METRICS_EXPORTER_ENABLED)
-endif
 
 ifdef IMAGE_NGINX_INIT
   IMAGE_NGINX_INIT_FIELD = , "nginx.initImage": "$(IMAGE_NGINX_INIT)"
@@ -56,8 +44,6 @@ APP_PARAMETERS ?= { \
   "name": "$(NAME)", \
   "namespace": "$(NAMESPACE)" \
   $(IMAGE_NGINX_INIT_FIELD) \
-  $(METRICS_EXPORTER_ENABLED_FIELD) \
-  $(CURATED_METRICS_EXPORTER_ENABLED_FIELD) \
   $(PUBLIC_IP_AVAILABLE_FIELD) \
 }
 

--- a/k8s/nginx/chart/nginx/templates/nginx-statefulset.yaml
+++ b/k8s/nginx/chart/nginx/templates/nginx-statefulset.yaml
@@ -100,46 +100,6 @@ spec:
         env:
         - name: "SCRAPE_URI"
           value: "http://localhost/stub_status"
-      {{ if .Values.metrics.curatedExporter.enabled }}
-      - name: prometheus-to-sd-curated
-        image: {{ .Values.metrics.image }}
-        ports:
-        - name: profiler
-          containerPort: 6060
-        command:
-        - /monitor
-        - --stackdriver-prefix=kubernetes.io
-        - --source=nginx:http://localhost:9113/metrics?customResourceType=k8s_container&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)&customLabels[container_name]=nginx
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      {{ end }}
-      {{ if .Values.metrics.exporter.enabled }}
-      - name: prometheus-to-sd
-        image: {{ .Values.metrics.image }}
-        ports:
-        - name: profiler
-          containerPort: 6060
-        command:
-        - /monitor
-        - --stackdriver-prefix=custom.googleapis.com
-        - --source=nginx:http://localhost:9113/metrics?customResourceType=k8s_container&customLabels[project_id]&customLabels[location]&customLabels[cluster_name]&customLabels[namespace_name]=$(POD_NAMESPACE)&customLabels[pod_name]=$(POD_NAME)&customLabels[container_name]=nginx
-        env:
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-      {{ end }}
       volumes:
       - name: certs
         secret:

--- a/k8s/nginx/chart/nginx/values.yaml
+++ b/k8s/nginx/chart/nginx/values.yaml
@@ -12,11 +12,5 @@ tls:
   base64EncodedCertificate: null
 exporter:
   image: null
-metrics:
-  image: null
-  curatedExporter:
-    enabled: true
-  exporter:
-    enabled: false
 publicIp:
   available: true

--- a/k8s/nginx/schema.yaml
+++ b/k8s/nginx/schema.yaml
@@ -33,10 +33,6 @@ x-google-marketplace:
       properties:
         exporter.image:
           type: FULL
-    prometheus-to-sd:
-      properties:
-        metrics.image:
-          type: FULL
 
 properties:
   name:
@@ -75,18 +71,6 @@ properties:
         generatedProperties:
           base64EncodedPrivateKey: tls.base64EncodedPrivateKey
           base64EncodedCertificate: tls.base64EncodedCertificate
-  metrics.curatedExporter.enabled:
-    type: boolean
-    title: Enable Stackdriver Metrics Exporter For Free Curated Metrics
-    description: Your GCP project should have Stackdriver enabled. Disable if you use
-      non-GCP clusters, because export of metrics to Stackdriver is not supported yet.
-    default: true
-  metrics.exporter.enabled:
-    type: boolean
-    title: Enable Stackdriver Metrics Exporter
-    description: Your GCP project should have Stackdriver enabled. For non-GCP clusters,
-      export of metrics to Stackdriver is not supported yet
-    default: false
   publicIp.available:
     type: boolean
     default: true
@@ -97,4 +81,3 @@ required:
 - name
 - namespace
 - nginx.replicas
-- metrics.exporter.enabled


### PR DESCRIPTION
Summary:
Cloud Monitoring / Stackdriver now recommends using [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) to export Prometheus-format metrics to Cloud Monitoring instead of the old `prometheus-to-sd` sidecar. Why this is preferable:
- the metrics are of the form `prometheus.googleapis.com/...` and work OOTB with PromQL in Cloud Monitoring and our OOTB dashboards and alerts
- collection scales better because GMP is deployed as a daemonset (one pod per node) instead of one sidecar for every application pod
- cheaper and billed in samples instead of bytes, which is easier to understand

As a result, this deletes the older and not recommended prometheus-to-sd sidecar from the click-to-deploy configuration as an option.