### PR TITLE
Update cassandra/templates/cassandra-statefulset to use monitored-resource-type-prefix

### DIFF
--- a/k8s/cassandra/chart/cassandra/templates/cassandra-statefulset.yaml
+++ b/k8s/cassandra/chart/cassandra/templates/cassandra-statefulset.yaml
@@ -96,7 +96,7 @@ spec:
         - --source=cassandra:http://localhost:9404/metrics
         - --pod-id=$(POD_NAME)
         - --namespace-id=$(POD_NAMESPACE)
-        - --monitored-resource-types=k8s
+        - --monitored-resource-type-prefix=k8s_
         env:
         - name: POD_NAME
           valueFrom:


### PR DESCRIPTION
Fix for #2863 
Update cassandra/templates/cassandra-statefulset to use `monitored-resource-type-prefix`

<!--- /gcbrun -->
