### PR TITLE
fix(k8s): resolve 404 dependency errors in Wordpress and NGINX builds

### DIFF
--- a/k8s/nginx/deployer/Dockerfile
+++ b/k8s/nginx/deployer/Dockerfile
@@ -28,6 +28,11 @@ RUN cat /tmp/apptest/schema.yaml \
     && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
+USER root
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list
 COPY --from=build /tmp/nginx.tar.gz /data/chart/
 COPY --from=build /tmp/test/nginx.tar.gz /data-test/chart/
 COPY --from=build /tmp/apptest/schema.yaml /data-test/

--- a/k8s/wordpress/Makefile
+++ b/k8s/wordpress/Makefile
@@ -19,9 +19,7 @@ IMAGE_WORDPRESS ?= $(SOURCE_REGISTRY)/wordpress6-php8-apache:$(TRACK)
 IMAGE_APACHE_EXPORTER ?= $(SOURCE_REGISTRY)/apache-exporter0:$(APACHE_EXPORTER_TAG)
 IMAGE_MYSQL ?= $(SOURCE_REGISTRY)/mariadb11:$(MARIADB_TAG)
 IMAGE_MYSQLD_EXPORTER ?= $(SOURCE_REGISTRY)/mysql8:exporter
-IMAGE_PROMETHEUS_TO_SD ?= eu.gcr.io/k8s-artifacts-prod/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
-
-
+IMAGE_PROMETHEUS_TO_SD ?= registry.k8s.io/prometheus-to-sd:$(METRICS_EXPORTER_TAG)
 # Main image
 image-$(CHART_NAME) := $(call get_sha256,$(IMAGE_WORDPRESS))
 

--- a/k8s/wordpress/deployer/Dockerfile
+++ b/k8s/wordpress/deployer/Dockerfile
@@ -28,6 +28,11 @@ RUN cat /tmp/apptest/schema.yaml \
     && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
 
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm:$MARKETPLACE_TOOLS_TAG
+USER root
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list && \
+    sed -i 's|security.debian.org/debian-security|archive.debian.org/debian-security|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list && \
+    sed -i '/buster-updates/d' /etc/apt/sources.list
 COPY --from=build /tmp/wordpress.tar.gz /data/chart/
 COPY --from=build /tmp/test/wordpress.tar.gz /data-test/chart/
 COPY --from=build /tmp/apptest/schema.yaml /data-test/


### PR DESCRIPTION
Root Cause 1: Debian 10 standard mirrors are EOL.
Fix 1: Redirected sources.list to archive.debian.org in deployer Dockerfiles.

Root Cause 2: Prometheus-to-sd moved from gcr.io to registry.k8s.io.
Fix 2: Updated IMAGE_PROMETHEUS_TO_SD in k8s/wordpress/Makefile.



<!--- /gcbrun -->
